### PR TITLE
feat: get counters in get_target_list

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1488,6 +1488,7 @@ function _M.get_target_list(name, shm_name)
   self.shm = ngx.shared[tostring(shm_name)]
   assert(self.shm, ("no shm found by name '%s'"):format(shm_name))
   self.TARGET_STATE     = SHM_PREFIX .. self.name .. ":state"
+  self.TARGET_COUNTER   = SHM_PREFIX .. self.name .. ":counter"
   self.TARGET_LIST      = SHM_PREFIX .. self.name .. ":target_list"
   self.TARGET_LIST_LOCK = SHM_PREFIX .. self.name .. ":target_list_lock"
   self.LOG_PREFIX       = LOG_PREFIX .. "(" .. self.name .. ") "
@@ -1504,6 +1505,25 @@ function _M.get_target_list(name, shm_name)
 
     return true
   end)
+
+  for _, target in ipairs(self.targets) do
+    target.counter = {
+      success = 0,
+      http_failure = 0,
+      tcp_failure = 0,
+      timeout_failure = 0,
+    }
+    locking_target(self, ip, port, hostname, function()
+      local counter = self.shm:get(key_for(self.TARGET_COUNTER,
+        target.ip, target.port, target.hostname))
+      target.counter = {
+        success = ctr_get(counter, CTR_SUCCESS),
+        http_failure = ctr_get(counter, CTR_HTTP),
+        tcp_failure = ctr_get(counter, CTR_TCP),
+        timeout_failure = ctr_get(counter, CTR_TIMEOUT),
+      }
+    end)
+  end
 
   if not ok then
     return nil, "Error loading target list: " .. err

--- a/t/get_target_list.t
+++ b/t/get_target_list.t
@@ -66,6 +66,10 @@ qq{
                 assert(node.ip == "127.0.0.1" or node.ip == "127.0.0.2", "invalid ip")
                 assert(node.port == 2116, "invalid port")
                 assert(node.status == "healthy", "invalid status")
+                assert(node.counter.success == 1, "invalid success counter")
+                assert(node.counter.tcp_failure == 0, "invalid tcp failure counter")
+                assert(node.counter.http_failure == 0, "invalid http failure counter")
+                assert(node.counter.timeout_failure == 0, "invalid timeout failure counter")
             end
         }
     }


### PR DESCRIPTION
Example:

```json
[
  {
    "name": "upstream#/apisix/routes/1",
    "nodes": [
      {
        "port": 80,
        "counter": {
          "success": 2,
          "tcp_failure": 0,
          "timeout_failure": 0,
          "http_failure": 0
        },
        "status": "healthy",
        "ip": "52.86.68.46"
      },
      {
        "port": 80,
        "counter": {
          "success": 0,
          "tcp_failure": 0,
          "timeout_failure": 0,
          "http_failure": 5
        },
        "status": "unhealthy",
        "ip": "34.195.115.181"
      }
    ]
  }
]

```