### PR TITLE
fix(timers): prevent exhausting timers in init/worker_init (#57)

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -134,6 +134,52 @@ local worker_color = use_color and function(str) return ("\027["..tostring(31 + 
 -- Debug function
 local function dump(...) print(require("pl.pretty").write({...})) end -- luacheck: ignore 211
 
+-- cache timers in "init", "init_worker" phases so we use only a single timer
+-- and do not run the risk of exhausting them for large sets
+-- see https://github.com/Kong/lua-resty-healthcheck/issues/40
+-- Below we'll temporarily use a patched version of ngx.timer.at, until we're
+-- past the init and init_worker phases, after which we'll return to the regular
+-- ngx.timer.at implementation
+local ngx_timer_at do
+  local callback_list = {}
+
+  local function handler(premature)
+    if premature then
+      return
+    end
+
+    local list = callback_list
+    callback_list = {}
+
+    for _, args in ipairs(list) do
+      local ok, err = pcall(args[1], ngx_worker_exiting(), unpack(args, 2, args.n))
+      if not ok then
+        ngx.log(ngx.ERR, "timer failure: ", err)
+      end
+    end
+  end
+
+  ngx_timer_at = function(...)
+    local phase = ngx.get_phase()
+    if phase ~= "init" and phase ~= "init_worker" then
+      -- we're past init/init_worker, so replace this temp function with the
+      -- real-deal again, so from here on we run regular timers.
+      ngx_timer_at = ngx.timer.at
+      return ngx.timer.at(...)
+    end
+
+    local n = #callback_list
+    callback_list[n+1] = { n = select("#", ...), ... }
+    if n == 0 then
+      -- first one, so schedule the actual timer
+      return ngx.timer.at(0, handler)
+    end
+    return true
+  end
+
+end
+
+
 local _M = {}
 
 
@@ -272,7 +318,7 @@ local function locking_target_list(self, fn)
 
   local ok, err = run_fn_locked_target_list(false, self, fn)
   if err == "failed to acquire lock" then
-    local _, terr = ngx.timer.at(0, run_fn_locked_target_list, self, fn)
+    local _, terr = ngx_timer_at(0, run_fn_locked_target_list, self, fn)
     if terr ~= nil then
       return nil, terr
     end
@@ -527,7 +573,7 @@ end
 local function locking_target(self, ip, port, hostname, fn)
   local ok, err = run_mutexed_fn(false, self, ip, port, hostname, fn)
   if err == "failed to acquire lock" then
-    local _, terr = ngx.timer.at(0, run_mutexed_fn, self, ip, port, hostname, fn)
+    local _, terr = ngx_timer_at(0, run_mutexed_fn, self, ip, port, hostname, fn)
     if terr ~= nil then
       return nil, terr
     end

--- a/readme.md
+++ b/readme.md
@@ -88,50 +88,10 @@ for the complete API.
 
 Versioning is strictly based on [Semantic Versioning](https://semver.org/)
 =======
-### Releasing new versions:
-
-* update changelog below (PR's should be merged including a changelog entry)
-* based on changelog determine new SemVer version
-* create a new rockspec
-* render the docs using `ldoc` (don't do this within PR's)
-* commit as "release x.x.x" (do not include rockspec revision)
-* tag the commit with "x.x.x" (do not include rockspec revision)
-* push commit and tag
-* upload rock to luarocks: `luarocks upload rockspecs/[name] --api-key=abc`
-
 ### Unreleased
-
-* BREAKING: fallback for deprecated top-level field `type` is now removed
-  (deprecated since `0.5.0`) [#56](https://github.com/Kong/lua-resty-healthcheck/pull/56)
-* BREAKING: Bump `lua-resty-worker-events` dependency to `2.0.0`. This makes
-  a lot of the APIs in this library asynchronous as the worker events `post`
-  and `post_local` won't anymore call `poll` on a running worker automatically,
-  for more information, see:
-  https://github.com/Kong/lua-resty-worker-events#200-16-september-2020
-* BREAKING: tcp_failures can no longer be 0 on http(s) checks (unless http(s)_failures
-  are also set to 0) [#55](https://github.com/Kong/lua-resty-healthcheck/pull/55)
-* feature: Added support for https_sni [#49](https://github.com/Kong/lua-resty-healthcheck/pull/49)
-* fix: properly log line numbers by using tail calls [#29](https://github.com/Kong/lua-resty-healthcheck/pull/29)
-* fix: when not providing a hostname, use IP [#48](https://github.com/Kong/lua-resty-healthcheck/pull/48)
-* fix: makefile; make install
-* feature: added a status version field [#54](https://github.com/Kong/lua-resty-healthcheck/pull/54)
-* feature: add headers for probe request [#54](https://github.com/Kong/lua-resty-healthcheck/pull/54)
-* fix: exit early when reloading during a probe [#47](https://github.com/Kong/lua-resty-healthcheck/pull/47)
-* fix: prevent target-list from being nil, due to async behaviour [#44](https://github.com/Kong/lua-resty-healthcheck/pull/44)
-* fix: replace timer and node-wide locks with resty-timer, to prevent interval
-  skips [#59](https://github.com/Kong/lua-resty-healthcheck/pull/59)
-* change: added additional logging on posting events [#25](https://github.com/Kong/lua-resty-healthcheck/issues/25)
 * fix: do not run out of timers during init/init_worker when adding a vast
   amount of targets [#57](https://github.com/Kong/lua-resty-healthcheck/pull/57)
 
-### 1.3.0 (17-Jun-2020)
-
-* Adds support to mTLS to active healthchecks. This feature  can be used adding
-  the fields `ssl_cert` and `ssl_key`, with certificate and key respectively,
-  when creating a new healthcheck object.
-  [#41](https://github.com/Kong/lua-resty-healthcheck/pull/41)
-
->>>>>>> d0d53a5 (fix(timers) prevent exhausting timers in init/worker_init (#57)):README.md
 ### 1.2.0 (13-Feb-2020)
 
  * Adds `set_all_target_statuses_for_hostname`, which sets the targets for

--- a/readme.md
+++ b/readme.md
@@ -87,7 +87,51 @@ for the complete API.
 ## History
 
 Versioning is strictly based on [Semantic Versioning](https://semver.org/)
+=======
+### Releasing new versions:
 
+* update changelog below (PR's should be merged including a changelog entry)
+* based on changelog determine new SemVer version
+* create a new rockspec
+* render the docs using `ldoc` (don't do this within PR's)
+* commit as "release x.x.x" (do not include rockspec revision)
+* tag the commit with "x.x.x" (do not include rockspec revision)
+* push commit and tag
+* upload rock to luarocks: `luarocks upload rockspecs/[name] --api-key=abc`
+
+### Unreleased
+
+* BREAKING: fallback for deprecated top-level field `type` is now removed
+  (deprecated since `0.5.0`) [#56](https://github.com/Kong/lua-resty-healthcheck/pull/56)
+* BREAKING: Bump `lua-resty-worker-events` dependency to `2.0.0`. This makes
+  a lot of the APIs in this library asynchronous as the worker events `post`
+  and `post_local` won't anymore call `poll` on a running worker automatically,
+  for more information, see:
+  https://github.com/Kong/lua-resty-worker-events#200-16-september-2020
+* BREAKING: tcp_failures can no longer be 0 on http(s) checks (unless http(s)_failures
+  are also set to 0) [#55](https://github.com/Kong/lua-resty-healthcheck/pull/55)
+* feature: Added support for https_sni [#49](https://github.com/Kong/lua-resty-healthcheck/pull/49)
+* fix: properly log line numbers by using tail calls [#29](https://github.com/Kong/lua-resty-healthcheck/pull/29)
+* fix: when not providing a hostname, use IP [#48](https://github.com/Kong/lua-resty-healthcheck/pull/48)
+* fix: makefile; make install
+* feature: added a status version field [#54](https://github.com/Kong/lua-resty-healthcheck/pull/54)
+* feature: add headers for probe request [#54](https://github.com/Kong/lua-resty-healthcheck/pull/54)
+* fix: exit early when reloading during a probe [#47](https://github.com/Kong/lua-resty-healthcheck/pull/47)
+* fix: prevent target-list from being nil, due to async behaviour [#44](https://github.com/Kong/lua-resty-healthcheck/pull/44)
+* fix: replace timer and node-wide locks with resty-timer, to prevent interval
+  skips [#59](https://github.com/Kong/lua-resty-healthcheck/pull/59)
+* change: added additional logging on posting events [#25](https://github.com/Kong/lua-resty-healthcheck/issues/25)
+* fix: do not run out of timers during init/init_worker when adding a vast
+  amount of targets [#57](https://github.com/Kong/lua-resty-healthcheck/pull/57)
+
+### 1.3.0 (17-Jun-2020)
+
+* Adds support to mTLS to active healthchecks. This feature  can be used adding
+  the fields `ssl_cert` and `ssl_key`, with certificate and key respectively,
+  when creating a new healthcheck object.
+  [#41](https://github.com/Kong/lua-resty-healthcheck/pull/41)
+
+>>>>>>> d0d53a5 (fix(timers) prevent exhausting timers in init/worker_init (#57)):README.md
 ### 1.2.0 (13-Feb-2020)
 
  * Adds `set_all_target_statuses_for_hostname`, which sets the targets for

--- a/t/02-add_target.t
+++ b/t/02-add_target.t
@@ -3,7 +3,7 @@ use Cwd qw(cwd);
 
 workers(1);
 
-plan tests => repeat_each() * (blocks() * 4) + 6;
+plan tests => repeat_each() * (blocks() * 4) + 5;
 
 my $pwd = cwd();
 
@@ -166,3 +166,89 @@ checking healthy targets: #1
 
 --- no_error_log
 checking unhealthy targets: #1
+
+
+
+=== TEST 4: calling add_target() repeatedly does not exhaust timers
+--- http_config eval
+qq{
+    $::HttpConfig
+
+    server {
+        listen 2113;
+        location = /status {
+            return 200;
+        }
+    }
+    lua_max_pending_timers 100;
+
+    init_worker_by_lua_block {
+        --error("erreur")
+        local resty_lock = require ("resty.lock")
+        local we = require "resty.worker.events"
+        assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+        local healthcheck = require("resty.healthcheck")
+        local checker = healthcheck.new({
+            name = "testing",
+            shm_name = "test_shm",
+            checks = {
+                active = {
+                    http_path = "/status",
+                    healthy  = {
+                        interval = 0.1,
+                        successes = 1,
+                    },
+                    unhealthy  = {
+                        interval = 0.1,
+                        tcp_failures = 1,
+                        http_failures = 1,
+                    }
+                }
+            }
+        })
+
+        -- lock the key, so adding targets will fallback on timers
+        local lock = assert(resty_lock:new(checker.shm_name, {
+            exptime = 10,  -- timeout after which lock is released anyway
+            timeout = 5,   -- max wait time to acquire lock
+        }))
+        assert(lock:lock(checker.TARGET_LIST_LOCK))
+
+        local addr = {
+            127, 0, 0, 1
+        }
+        -- add 10000 check, exhausting timers...
+        for i = 0, 150 do
+            addr[4] = addr[4] + 1
+            if addr[4] > 255 then
+                addr[4] = 1
+                addr[3] = addr[3] + 1
+                if addr[3] > 255 then
+                    addr[3] = 1
+                    addr[2] = addr[2] + 1
+                    if addr[2] > 255 then
+                        addr[2] = 1
+                        addr[1] = addr[1] + 1
+                    end
+                end
+            end
+            local ok, err = assert(checker:add_target(table.concat(addr, "."), 2113, nil, true))
+        end
+    }
+
+}
+
+--- config
+    location = /t {
+        content_by_lua_block {
+            ngx.say(true)
+            ngx.exit(200)
+        }
+    }
+
+--- request
+GET /t
+--- response_body
+true
+--- no_error_log
+too many pending timers


### PR DESCRIPTION
fix: https://github.com/Kong/lua-resty-healthcheck/issues/40

backport patch.