### PR TITLE
fix: check lock result

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -268,7 +268,6 @@ end
 --- Helper function to run the function holding a lock on the target list.
 -- @see locking_target_list
 local function run_fn_locked_target_list(premature, self, fn)
-
   if premature then
     return
   end
@@ -282,31 +281,36 @@ local function run_fn_locked_target_list(premature, self, fn)
     return nil, "failed to create lock:" .. lock_err
   end
 
-  local pok, perr = pcall(tl_lock.lock, tl_lock, self.TARGET_LIST_LOCK)
-  if not pok then
-    self:log(DEBUG, "failed to acquire lock: ", perr)
-    return nil, "failed to acquire lock"
+  local elapsed, err = tl_lock:lock(self.TARGET_LIST_LOCK)
+  if not elapsed then
+    local err_msg = "failed to acquire lock for '" .. self.TARGET_LIST_LOCK .. "': " .. err
+    self:log(DEBUG, err_msg)
+    return nil, err_msg
   end
+
+  local final_res, final_err
 
   local target_list, err = fetch_target_list(self)
+  if not target_list then
+    final_res, final_err = nil, err
 
-  local final_ok, final_err
-
-  if target_list then
-    final_ok, final_err = pcall(fn, target_list)
   else
-    final_ok, final_err = nil, err
+    local status, retval1_or_errmsg, retval2 = pcall(fn, target_list)
+    if not status then
+      final_res, final_err = nil, retval1_or_errmsg
+    else
+      final_res, final_err = retval1_or_errmsg, retval2
+    end
   end
 
-  local ok
-  ok, err = tl_lock:unlock()
+  local ok, err = tl_lock:unlock()
   if not ok then
     -- recoverable: not returning this error, only logging it
     self:log(ERR, "failed to release lock '", self.TARGET_LIST_LOCK,
         "': ", err)
   end
 
-  return final_ok, final_err
+  return final_res, final_err
 end
 
 

--- a/t/lock-failed.t
+++ b/t/lock-failed.t
@@ -1,0 +1,80 @@
+use Test::Nginx::Socket::Lua 'no_plan';
+use Cwd qw(cwd);
+
+workers(1);
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/deps/share/lua/5.1/?/init.lua;$pwd/deps/share/lua/5.1/?.lua;;$pwd/lib/?.lua;;";
+    lua_shared_dict test_shm 8m;
+    lua_shared_dict my_worker_events 8m;
+};
+
+no_shuffle();
+run_tests();
+
+__DATA__
+
+
+=== TEST 1: acquire lock timeout
+--- http_config eval
+qq{
+    $::HttpConfig
+
+    server {
+        listen 2116;
+        location = /status {
+            return 200;
+        }
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local resty_lock = require ("resty.lock")
+
+            local shm_name = "test_shm"
+            local name = "testing"
+            local key = "lua-resty-healthcheck:" .. name ..  ":target_list_lock"
+
+            local tl_lock, lock_err = resty_lock:new(shm_name, {
+                exptime = 10,  -- timeout after which lock is released anyway
+                timeout = 5,   -- max wait time to acquire lock
+            })
+            assert(tl_lock, "new lock failed")
+
+            local elapsed, err = tl_lock:lock(key)
+            assert(elapsed, "lock failed")
+
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+            local healthcheck = require("resty.healthcheck")
+            local ok, err = healthcheck.new({
+                name = name,
+                shm_name = shm_name,
+                type = "http",
+                checks = {
+                    active = {
+                        http_path = "/status",
+                        healthy  = {
+                            interval = 0.1, -- we don't want active checks
+                            successes = 1,
+                        },
+                        unhealthy  = {
+                            interval = 0.1, -- we don't want active checks
+                            tcp_failures = 3,
+                            http_failures = 3,
+                        }
+                    }
+                }
+            })
+            assert(ok == nil, "lock success")
+            ngx.log(ngx.ERR, err)
+        }
+    }
+--- request
+GET /t
+--- error_log
+failed to acquire lock for 'lua-resty-healthcheck:testing:target_list_lock': timeout
+--- timeout: 10

--- a/t/lock-failed.t
+++ b/t/lock-failed.t
@@ -32,21 +32,20 @@ qq{
 --- config
     location = /t {
         content_by_lua_block {
+            -- add a lock manually
             local resty_lock = require ("resty.lock")
-
             local shm_name = "test_shm"
             local name = "testing"
             local key = "lua-resty-healthcheck:" .. name ..  ":target_list_lock"
-
             local tl_lock, lock_err = resty_lock:new(shm_name, {
                 exptime = 10,  -- timeout after which lock is released anyway
                 timeout = 5,   -- max wait time to acquire lock
             })
             assert(tl_lock, "new lock failed")
-
             local elapsed, err = tl_lock:lock(key)
             assert(elapsed, "lock failed")
 
+            -- acquire a lock in the new function
             local we = require "resty.worker.events"
             assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
             local healthcheck = require("resty.healthcheck")


### PR DESCRIPTION
This fixes a bug in the `run_fn_locked_target_list` function. The function wraps `resty.lock:lock()` with pcall, but it was only checking the pcall return status and not the actual result of the lock operation. Therefore it would continue even if no lock was acquired.