### PR TITLE
fix: check lock result in run mutexed fn

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -552,15 +552,24 @@ local function run_mutexed_fn(premature, self, ip, port, hostname, fn)
   if not tlock then
     return nil, "failed to create lock:" .. lock_err
   end
+
   local lock_key = key_for(self.TARGET_LOCK, ip, port, hostname)
 
-  local pok, perr = pcall(tlock.lock, tlock, lock_key)
-  if not pok then
-    self:log(DEBUG, "failed to acquire lock: ", perr)
-    return nil, "failed to acquire lock"
+  local elapsed, err = tlock:lock(lock_key)
+  if not elapsed then
+    local err_msg = "failed to acquire lock for '" .. lock_key .. "': " .. err
+    self:log(DEBUG, err_msg)
+    return nil, err_msg
   end
 
-  local final_ok, final_err = pcall(fn)
+  local final_res, final_err
+
+  local status, retval1_or_errmsg, retval2 = pcall(fn)
+  if not status then
+    final_res, final_err = nil, retval1_or_errmsg
+  else
+    final_res, final_err = retval1_or_errmsg, retval2
+  end
 
   local ok, err = tlock:unlock()
   if not ok then
@@ -568,8 +577,7 @@ local function run_mutexed_fn(premature, self, ip, port, hostname, fn)
     self:log(ERR, "failed to release lock '", lock_key, "': ", err)
   end
 
-  return final_ok, final_err
-
+  return final_res, final_err
 end
 
 

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -554,7 +554,6 @@ local function run_mutexed_fn(premature, self, ip, port, hostname, fn)
   end
 
   local lock_key = key_for(self.TARGET_LOCK, ip, port, hostname)
-
   local elapsed, err = tlock:lock(lock_key)
   if not elapsed then
     local err_msg = "failed to acquire lock for '" .. lock_key .. "': " .. err


### PR DESCRIPTION
wraps resty.lock:lock() with pcall, but it was only checking the pcall return status and not the actual result of the lock operation. Therefore it would continue even if no lock was acquired.