### PR TITLE
fix: do not post event when do clear

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -520,9 +520,6 @@ function checker:clear()
 
     self.targets = {}
 
-    -- raise event for our removed target
-    self:raise_event(self.events.clear)
-
     return true
   end)
 end

--- a/t/worker-events/11-clear.t
+++ b/t/worker-events/11-clear.t
@@ -3,7 +3,7 @@ use Cwd qw(cwd);
 
 workers(1);
 
-plan tests => repeat_each() * 23;
+plan tests => repeat_each() * 25;
 
 my $pwd = cwd();
 


### PR DESCRIPTION
There is no need to post event because each progress will do the clear operation in APISIX.
If we post the event, every progress will do the clear opeartion n times (n is the number of progress)