### PR TITLE
fix: fallback hostname to ip like add_target and get_target

### DIFF
--- a/.github/workflows/build_and_test_with_resty_events.yml
+++ b/.github/workflows/build_and_test_with_resty_events.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: CI using lua-resty-events
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         openresty-version: [1.21.4.1]
@@ -24,10 +24,10 @@ jobs:
       - name: Set environment variables
         env:
           OPENRESTY_VER: ${{ matrix.openresty-version }}
-          RESTY_EVENTS_VER: 0.1.2
-          LUAROCKS_VER: 3.9.0
-          OPENSSL_VER: 1.1.1q
-          PCRE_VER: 8.45
+          RESTY_EVENTS_VER: 0.3.0
+          LUAROCKS_VER: 3.12.0
+          OPENSSL_VER: 3.4.1
+          PCRE_VER: 10.45
         run: |
           echo "INSTALL_ROOT=/home/runner/work/cache/install-root" >> $GITHUB_ENV
           echo "DOWNLOAD_ROOT=/home/runner/work/cache/download-root" >> $GITHUB_ENV
@@ -39,16 +39,16 @@ jobs:
           echo "LD_LIBRARY_PATH=$HOME/install-root/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Checkout lua-resty-healthcheck
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # - name: Lookup build cache
-      #   uses: actions/cache@v3
-      #   id: cache-deps
-      #   with:
-      #     path: |
-      #       /home/runner/work/cache/install-root
-      #       /home/runner/work/cache/download-root
-      #     key: ${{ runner.os }}-${{ hashFiles('**/.github/workflows/build_and_test_with_resty_events.yml') }}-${{ matrix.openresty-version }}
+      - name: Lookup build cache
+        uses: actions/cache@v4
+        id: cache-deps
+        with:
+          path: |
+            /home/runner/work/cache/install-root
+            /home/runner/work/cache/download-root
+          key: ${{ runner.os }}-${{ hashFiles('**/.github/workflows/build_and_test_with_resty_events.yml') }}-${{ matrix.openresty-version }}
 
       - name: Add to Path
         if: steps.cache-deps.outputs.cache-hit != 'true'
@@ -65,8 +65,7 @@ jobs:
           make install_sw
 
       - name: Checkout lua-resty-events
-        uses: actions/checkout@v3
-        if: steps.cache-deps.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
         with:
           repository: Kong/lua-resty-events
           ref: refs/tags/0.1.0

--- a/.github/workflows/build_and_test_with_worker_events.yml
+++ b/.github/workflows/build_and_test_with_worker_events.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   build:
     name: CI using lua-resty-worker-events
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        openresty-version: [1.21.4.1]
+        openresty-version: [1.27.1.2]
 
     steps:
       - name: Update and install OS dependencies
@@ -28,17 +28,17 @@ jobs:
           echo "/usr/local/openresty/nginx/sbin" >> $GITHUB_PATH
 
       - name: Checkout lua-resty-healthcheck
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install OpenResty ${{ matrix.openresty-version }}
         env:
           OPENRESTY_VER: ${{ matrix.openresty-version }}
         run: |
           sudo apt-get -y install --no-install-recommends wget gnupg ca-certificates
-          wget -O - https://openresty.org/package/pubkey.gpg | sudo apt-key add -
-          echo "deb http://openresty.org/package/ubuntu $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/openresty.list
+          wget -O - https://openresty.org/package/pubkey.gpg | sudo gpg --dearmor -o /usr/share/keyrings/openresty.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openresty.gpg] http://openresty.org/package/ubuntu $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/openresty.list > /dev/null
           sudo apt-get update
-          sudo apt-get -y install openresty=$OPENRESTY_VER-1~focal1
+          sudo apt-get -y install openresty=$OPENRESTY_VER-1~jammy1
 
       - name: Install LuaRocks
         run: sudo apt-get install -y luarocks
@@ -53,6 +53,9 @@ jobs:
           sudo apt-get install cpanminus
           cpanm --notest --local-lib=$HOME/perl5 local::lib && eval $(perl -I $HOME/perl5/lib/perl5/ -Mlocal::lib)
           cpanm --notest Test::Nginx
+
+      - name: Checkout lua-resty-healthcheck
+        uses: actions/checkout@v4
 
       - name: Install lua-resty-healthcheck
         run: sudo luarocks make lua-resty-healthcheck-scm-1.rockspec

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -980,6 +980,7 @@ function checker:set_target_status(ip, port, hostname, is_healthy)
   ip   = tostring(assert(ip, "no ip address provided"))
   port = assert(tonumber(port), "no port number provided")
   assert(type(is_healthy) == "boolean")
+  hostname = hostname or ip
 
   local health_report = is_healthy and "healthy" or "unhealthy"
 

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -755,6 +755,7 @@ local function incr_counter(self, health_report, ip, port, hostname, limit, ctr_
     return true
   end
 
+  hostname = hostname or ip
   port = tonumber(port)
   local target = get_target(self, ip, port, hostname)
   if not target then

--- a/t/with_resty-events/04-report_success.t
+++ b/t/with_resty-events/04-report_success.t
@@ -105,14 +105,14 @@ GET /t
 true
 true
 --- error_log
-healthy SUCCESS increment (1/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (2/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (3/3) for '(127.0.0.1:2116)'
-event: target status '(127.0.0.1:2116)' from 'false' to 'true'
-healthy SUCCESS increment (1/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (2/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (3/3) for '(127.0.0.1:2116)'
-event: target status '(127.0.0.1:2118)' from 'false' to 'true'
+healthy SUCCESS increment (1/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (2/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (3/3) for '127.0.0.1(127.0.0.1:2116)'
+event: target status '127.0.0.1(127.0.0.1:2116)' from 'false' to 'true'
+healthy SUCCESS increment (1/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (2/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (3/3) for '127.0.0.1(127.0.0.1:2116)'
+event: target status '127.0.0.1(127.0.0.1:2118)' from 'false' to 'true'
 
 
 === TEST 2: report_success() recovers TCP active = passive
@@ -180,14 +180,14 @@ GET /t
 true
 true
 --- error_log
-healthy SUCCESS increment (1/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (2/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (3/3) for '(127.0.0.1:2116)'
-event: target status '(127.0.0.1:2116)' from 'false' to 'true'
-healthy SUCCESS increment (1/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (2/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (3/3) for '(127.0.0.1:2116)'
-event: target status '(127.0.0.1:2118)' from 'false' to 'true'
+healthy SUCCESS increment (1/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (2/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (3/3) for '127.0.0.1(127.0.0.1:2116)'
+event: target status '127.0.0.1(127.0.0.1:2116)' from 'false' to 'true'
+healthy SUCCESS increment (1/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (2/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (3/3) for '127.0.0.1(127.0.0.1:2116)'
+event: target status '127.0.0.1(127.0.0.1:2118)' from 'false' to 'true'
 
 === TEST 3: report_success() is a nop when active.healthy.sucesses == 0
 --- http_config eval
@@ -249,7 +249,7 @@ GET /t
 false
 --- no_error_log
 healthy SUCCESS increment
-event: target status '127.0.0.1 (127.0.0.1:2116)' from 'false' to 'true'
+event: target status '127.0.0.1(127.0.0.1:2116)' from 'false' to 'true'
 
 
 
@@ -313,4 +313,4 @@ GET /t
 false
 --- no_error_log
 healthy SUCCESS increment
-event: target status '(127.0.0.1:2118)' from 'false' to 'true'
+event: target status '127.0.0.1(127.0.0.1:2118)' from 'false' to 'true'

--- a/t/with_resty-events/05-report_failure.t
+++ b/t/with_resty-events/05-report_failure.t
@@ -105,14 +105,14 @@ GET /t
 false
 false
 --- error_log
-unhealthy HTTP increment (1/3) for '(127.0.0.1:2117)'
-unhealthy HTTP increment (2/3) for '(127.0.0.1:2117)'
-unhealthy HTTP increment (3/3) for '(127.0.0.1:2117)'
-event: target status '(127.0.0.1:2117)' from 'true' to 'false'
-unhealthy HTTP increment (1/3) for '(127.0.0.1:2113)'
-unhealthy HTTP increment (2/3) for '(127.0.0.1:2113)'
-unhealthy HTTP increment (3/3) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'true' to 'false'
+unhealthy HTTP increment (1/3) for '127.0.0.1(127.0.0.1:2117)'
+unhealthy HTTP increment (2/3) for '127.0.0.1(127.0.0.1:2117)'
+unhealthy HTTP increment (3/3) for '127.0.0.1(127.0.0.1:2117)'
+event: target status '127.0.0.1(127.0.0.1:2117)' from 'true' to 'false'
+unhealthy HTTP increment (1/3) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy HTTP increment (2/3) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy HTTP increment (3/3) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'true' to 'false'
 
 
 === TEST 2: report_failure() fails TCP active + passive
@@ -180,12 +180,12 @@ GET /t
 false
 false
 --- error_log
-unhealthy TCP increment (1/2) for '(127.0.0.1:2117)'
-unhealthy TCP increment (2/2) for '(127.0.0.1:2117)'
-event: target status '(127.0.0.1:2117)' from 'true' to 'false'
-unhealthy TCP increment (1/2) for '(127.0.0.1:2113)'
-unhealthy TCP increment (2/2) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'true' to 'false'
+unhealthy TCP increment (1/2) for '127.0.0.1(127.0.0.1:2117)'
+unhealthy TCP increment (2/2) for '127.0.0.1(127.0.0.1:2117)'
+event: target status '127.0.0.1(127.0.0.1:2117)' from 'true' to 'false'
+unhealthy TCP increment (1/2) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy TCP increment (2/2) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'true' to 'false'
 
 
 === TEST 3: report_failure() is a nop when failure counters == 0
@@ -253,9 +253,9 @@ GET /t
 true
 true
 --- no_error_log
-unhealthy TCP increment (1/2) for '(127.0.0.1:2117)'
-unhealthy TCP increment (2/2) for '(127.0.0.1:2117)'
-event: target status '(127.0.0.1:2117)' from 'true' to 'false'
-unhealthy TCP increment (1/2) for '(127.0.0.1:2113)'
-unhealthy TCP increment (2/2) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'true' to 'false'
+unhealthy TCP increment (1/2) for '127.0.0.1(127.0.0.1:2117)'
+unhealthy TCP increment (2/2) for '127.0.0.1(127.0.0.1:2117)'
+event: target status '127.0.0.1(127.0.0.1:2117)' from 'true' to 'false'
+unhealthy TCP increment (1/2) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy TCP increment (2/2) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'true' to 'false'

--- a/t/with_resty-events/06-report_http_status.t
+++ b/t/with_resty-events/06-report_http_status.t
@@ -105,14 +105,14 @@ GET /t
 false
 false
 --- error_log
-unhealthy HTTP increment (1/3) for '(127.0.0.1:2119)'
-unhealthy HTTP increment (2/3) for '(127.0.0.1:2119)'
-unhealthy HTTP increment (3/3) for '(127.0.0.1:2119)'
-event: target status '(127.0.0.1:2119)' from 'true' to 'false'
-unhealthy HTTP increment (1/3) for '(127.0.0.1:2113)'
-unhealthy HTTP increment (2/3) for '(127.0.0.1:2113)'
-unhealthy HTTP increment (3/3) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'true' to 'false'
+unhealthy HTTP increment (1/3) for '127.0.0.1(127.0.0.1:2119)'
+unhealthy HTTP increment (2/3) for '127.0.0.1(127.0.0.1:2119)'
+unhealthy HTTP increment (3/3) for '127.0.0.1(127.0.0.1:2119)'
+event: target status '127.0.0.1(127.0.0.1:2119)' from 'true' to 'false'
+unhealthy HTTP increment (1/3) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy HTTP increment (2/3) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy HTTP increment (3/3) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'true' to 'false'
 
 
 
@@ -183,16 +183,16 @@ GET /t
 true
 true
 --- error_log
-healthy SUCCESS increment (1/4) for '(127.0.0.1:2119)'
-healthy SUCCESS increment (2/4) for '(127.0.0.1:2119)'
-healthy SUCCESS increment (3/4) for '(127.0.0.1:2119)'
-healthy SUCCESS increment (4/4) for '(127.0.0.1:2119)'
-event: target status '(127.0.0.1:2119)' from 'false' to 'true'
-healthy SUCCESS increment (1/4) for '(127.0.0.1:2113)'
-healthy SUCCESS increment (2/4) for '(127.0.0.1:2113)'
-healthy SUCCESS increment (3/4) for '(127.0.0.1:2113)'
-healthy SUCCESS increment (4/4) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'false' to 'true'
+healthy SUCCESS increment (1/4) for '127.0.0.1(127.0.0.1:2119)'
+healthy SUCCESS increment (2/4) for '127.0.0.1(127.0.0.1:2119)'
+healthy SUCCESS increment (3/4) for '127.0.0.1(127.0.0.1:2119)'
+healthy SUCCESS increment (4/4) for '127.0.0.1(127.0.0.1:2119)'
+event: target status '127.0.0.1(127.0.0.1:2119)' from 'false' to 'true'
+healthy SUCCESS increment (1/4) for '127.0.0.1(127.0.0.1:2113)'
+healthy SUCCESS increment (2/4) for '127.0.0.1(127.0.0.1:2113)'
+healthy SUCCESS increment (3/4) for '127.0.0.1(127.0.0.1:2113)'
+healthy SUCCESS increment (4/4) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'false' to 'true'
 
 
 === TEST 3: report_http_status() with success is a nop when passive.healthy.successes == 0
@@ -256,7 +256,7 @@ GET /t
 false
 --- no_error_log
 healthy SUCCESS increment
-event: target status '127.0.0.1 (127.0.0.1:2119)' from 'false' to 'true'
+event: target status '127.0.0.1(127.0.0.1:2119)' from 'false' to 'true'
 
 
 === TEST 4: report_http_status() with success is a nop when active.healthy.successes == 0
@@ -320,7 +320,7 @@ GET /t
 false
 --- no_error_log
 healthy SUCCESS increment
-event: target status '127.0.0.1 (127.0.0.1:2119)' from 'false' to 'true'
+event: target status '127.0.0.1(127.0.0.1:2119)' from 'false' to 'true'
 
 
 === TEST 5: report_http_status() with failure is a nop when passive.unhealthy.http_failures == 0
@@ -384,7 +384,7 @@ GET /t
 true
 --- no_error_log
 unhealthy HTTP increment
-event: target status '127.0.0.1 (127.0.0.1:2119)' from 'true' to 'false'
+event: target status '127.0.0.1(127.0.0.1:2119)' from 'true' to 'false'
 
 
 === TEST 4: report_http_status() with success is a nop when active.unhealthy.http_failures == 0
@@ -448,7 +448,7 @@ GET /t
 true
 --- no_error_log
 unhealthy HTTP increment
-event: target status '(127.0.0.1:2119)' from 'true' to 'false'
+event: target status '127.0.0.1(127.0.0.1:2119)' from 'true' to 'false'
 
 
 === TEST 5: report_http_status() must work in log phase

--- a/t/with_resty-events/07-report_tcp_failure.t
+++ b/t/with_resty-events/07-report_tcp_failure.t
@@ -105,14 +105,14 @@ GET /t
 false
 false
 --- error_log
-unhealthy TCP increment (1/3) for '(127.0.0.1:2120)'
-unhealthy TCP increment (2/3) for '(127.0.0.1:2120)'
-unhealthy TCP increment (3/3) for '(127.0.0.1:2120)'
-event: target status '(127.0.0.1:2120)' from 'true' to 'false'
-unhealthy TCP increment (1/3) for '(127.0.0.1:2113)'
-unhealthy TCP increment (2/3) for '(127.0.0.1:2113)'
-unhealthy TCP increment (3/3) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'true' to 'false'
+unhealthy TCP increment (1/3) for '127.0.0.1(127.0.0.1:2120)'
+unhealthy TCP increment (2/3) for '127.0.0.1(127.0.0.1:2120)'
+unhealthy TCP increment (3/3) for '127.0.0.1(127.0.0.1:2120)'
+event: target status '127.0.0.1(127.0.0.1:2120)' from 'true' to 'false'
+unhealthy TCP increment (1/3) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy TCP increment (2/3) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy TCP increment (3/3) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'true' to 'false'
 
 
 === TEST 2: report_tcp_failure() for active is a nop when active.unhealthy.tcp_failures == 0
@@ -175,7 +175,7 @@ GET /t
 true
 --- no_error_log
 unhealthy TCP increment
-event: target status '(127.0.0.1:2120)' from 'true' to 'false'
+event: target status '127.0.0.1(127.0.0.1:2120)' from 'true' to 'false'
 
 
 
@@ -239,4 +239,4 @@ GET /t
 true
 --- no_error_log
 unhealthy TCP increment
-event: target status '(127.0.0.1:2120)' from 'true' to 'false'
+event: target status '127.0.0.1(127.0.0.1:2120)' from 'true' to 'false'

--- a/t/with_resty-events/08-report_timeout.t
+++ b/t/with_resty-events/08-report_timeout.t
@@ -105,12 +105,12 @@ GET /t
 false
 false
 --- error_log
-unhealthy TIMEOUT increment (1/2) for '(127.0.0.1:2122)'
-unhealthy TIMEOUT increment (2/2) for '(127.0.0.1:2122)'
-event: target status '(127.0.0.1:2122)' from 'true' to 'false'
-unhealthy TIMEOUT increment (1/2) for '(127.0.0.1:2113)'
-unhealthy TIMEOUT increment (2/2) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'true' to 'false'
+unhealthy TIMEOUT increment (1/2) for '127.0.0.1(127.0.0.1:2122)'
+unhealthy TIMEOUT increment (2/2) for '127.0.0.1(127.0.0.1:2122)'
+event: target status '127.0.0.1(127.0.0.1:2122)' from 'true' to 'false'
+unhealthy TIMEOUT increment (1/2) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy TIMEOUT increment (2/2) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'true' to 'false'
 
 
 === TEST 2: report_timeout() for active is a nop when active.unhealthy.timeouts == 0
@@ -175,7 +175,7 @@ GET /t
 true
 --- no_error_log
 unhealthy TCP increment
-event: target status '(127.0.0.1:2122)' from 'true' to 'false'
+event: target status '127.0.0.1(127.0.0.1:2122)' from 'true' to 'false'
 
 
 
@@ -241,4 +241,4 @@ GET /t
 true
 --- no_error_log
 unhealthy TCP increment
-event: target status '(127.0.0.1:2122)' from 'true' to 'false'
+event: target status '127.0.0.1(127.0.0.1:2122)' from 'true' to 'false'

--- a/t/with_resty-events/11-clear.t
+++ b/t/with_resty-events/11-clear.t
@@ -185,7 +185,7 @@ true
 unhealthy HTTP increment (1/3) for '127.0.0.1(127.0.0.1:21120)'
 unhealthy HTTP increment (2/3) for '127.0.0.1(127.0.0.1:21120)'
 --- no_error_log
-unhealthy HTTP increment (3/3) for '(127.0.0.1:21120)'
+unhealthy HTTP increment (3/3) for '127.0.0.1(127.0.0.1:21120)'
 
 
 === TEST 4: delayed_clear() clears the list, after interval new checkers don't see it

--- a/t/with_resty-events/12-set_target_status.t
+++ b/t/with_resty-events/12-set_target_status.t
@@ -159,7 +159,7 @@ true
 false
 
 
-=== TEST 4: set_target_status() resets the success counters
+=== TEST 3: set_target_status() resets the success counters
 --- http_config eval
 qq{
     $::HttpConfig

--- a/t/with_resty-events/12-set_target_status.t
+++ b/t/with_resty-events/12-set_target_status.t
@@ -159,7 +159,7 @@ true
 false
 
 
-=== TEST 3: set_target_status() resets the success counters
+=== TEST 4: set_target_status() resets the success counters
 --- http_config eval
 qq{
     $::HttpConfig

--- a/t/with_resty-events/15-get_virtualhost_target_status.t
+++ b/t/with_resty-events/15-get_virtualhost_target_status.t
@@ -171,8 +171,8 @@ true
 true
 false
 --- error_log
-unhealthy HTTP increment (1/1) for '(127.0.0.1:2116)'
-event: target status '(127.0.0.1:2116)' from 'true' to 'false'
+unhealthy HTTP increment (1/1) for '127.0.0.1(127.0.0.1:2116)'
+event: target status '127.0.0.1(127.0.0.1:2116)' from 'true' to 'false'
 
 
 
@@ -316,7 +316,7 @@ false
 false
 false
 --- error_log
-unhealthy HTTP increment (1/1) for '(127.0.0.1:2118)'
-event: target status '(127.0.0.1:2118)' from 'true' to 'false'
+unhealthy HTTP increment (1/1) for '127.0.0.1(127.0.0.1:2118)'
+event: target status '127.0.0.1(127.0.0.1:2118)' from 'true' to 'false'
 unhealthy HTTP increment (1/1) for '127.0.0.1(127.0.0.1:2119)'
 event: target status '127.0.0.1(127.0.0.1:2119)' from 'true' to 'false'

--- a/t/with_resty-events/98-get_target_list.t
+++ b/t/with_resty-events/98-get_target_list.t
@@ -181,9 +181,11 @@ qq{
     location = /t {
         content_by_lua_block {
             local healthcheck = require("resty.healthcheck")
+            local name = "testing"
+            local shm_name = "test_shm"
             local checker = healthcheck.new({
-                name = "testing",
-                shm_name = "test_shm",
+                name = name,
+                shm_name = shm_name,
 events_module = "resty.events",
                 type = "http",
                 checks = {
@@ -216,7 +218,7 @@ events_module = "resty.events",
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
             checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
             ngx.sleep(0.01)
-            assert(checker:get_target_status("127.0.0.1", 2119), false)
+            assert(checker:get_target_status("127.0.0.1", 2119) == false, "target should be unhealthy")
             local nodes = healthcheck.get_target_list(name, shm_name)
             assert(#nodes == 1, "invalid number of nodes")
             assert(nodes[1].ip == "127.0.0.1", "invalid ip")
@@ -231,7 +233,7 @@ events_module = "resty.events",
 --- request
 GET /t
 --- error_log
-unhealthy HTTP increment (1/3) for '(127.0.0.1:2119)'
-unhealthy HTTP increment (2/3) for '(127.0.0.1:2119)'
-unhealthy HTTP increment (3/3) for '(127.0.0.1:2119)'
-event: target status '(127.0.0.1:2119)' from 'true' to 'falsedf'
+unhealthy HTTP increment (1/3) for '127.0.0.1(127.0.0.1:2119)'
+unhealthy HTTP increment (2/3) for '127.0.0.1(127.0.0.1:2119)'
+unhealthy HTTP increment (3/3) for '127.0.0.1(127.0.0.1:2119)'
+event: target status '127.0.0.1(127.0.0.1:2119)' from 'true' to 'false'

--- a/t/with_resty-events/98-get_target_list.t
+++ b/t/with_resty-events/98-get_target_list.t
@@ -186,7 +186,7 @@ qq{
             local checker = healthcheck.new({
                 name = name,
                 shm_name = shm_name,
-events_module = "resty.events",
+                events_module = "resty.events",
                 type = "http",
                 checks = {
                     active = {

--- a/t/with_resty-events/98-get_target_list.t
+++ b/t/with_resty-events/98-get_target_list.t
@@ -162,3 +162,76 @@ GET /t
 --- no_error_log
 [error]
 --- timeout: 5
+
+
+
+=== TEST 3: passive healthcheck without hostname
+--- http_config eval
+qq{
+    $::HttpConfig
+
+    server {
+        listen 2119;
+        location = /status {
+            return 200;
+        }
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local healthcheck = require("resty.healthcheck")
+            local checker = healthcheck.new({
+                name = "testing",
+                shm_name = "test_shm",
+events_module = "resty.events",
+                type = "http",
+                checks = {
+                    active = {
+                        http_path = "/status",
+                        healthy  = {
+                            interval = 999, -- we don't want active checks
+                            successes = 3,
+                        },
+                        unhealthy  = {
+                            interval = 999, -- we don't want active checks
+                            tcp_failures = 2,
+                            http_failures = 3,
+                        }
+                    },
+                    passive = {
+                        healthy  = {
+                            successes = 3,
+                        },
+                        unhealthy  = {
+                            tcp_failures = 2,
+                            http_failures = 3,
+                        }
+                    }
+                }
+            })
+            local ok, err = checker:add_target("127.0.0.1", 2119, nil, true)
+            ngx.sleep(0.01)
+            checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
+            checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
+            checker:report_http_status("127.0.0.1", 2119, nil, 500, "passive")
+            ngx.sleep(0.01)
+            assert(checker:get_target_status("127.0.0.1", 2119), false)
+            local nodes = healthcheck.get_target_list(name, shm_name)
+            assert(#nodes == 1, "invalid number of nodes")
+            assert(nodes[1].ip == "127.0.0.1", "invalid ip")
+            assert(nodes[1].port == 2119, "invalid port")
+            assert(nodes[1].status == "unhealthy", "invalid status")
+            assert(nodes[1].counter.success == 0, "invalid success counter")
+            assert(nodes[1].counter.tcp_failure == 0, "invalid tcp failure counter")
+            assert(nodes[1].counter.http_failure == 3, "invalid http failure counter")
+            assert(nodes[1].counter.timeout_failure == 0, "invalid timeout failure counter")
+        }
+    }
+--- request
+GET /t
+--- error_log
+unhealthy HTTP increment (1/3) for '(127.0.0.1:2119)'
+unhealthy HTTP increment (2/3) for '(127.0.0.1:2119)'
+unhealthy HTTP increment (3/3) for '(127.0.0.1:2119)'
+event: target status '(127.0.0.1:2119)' from 'true' to 'falsedf'

--- a/t/with_worker-events/04-report_success.t
+++ b/t/with_worker-events/04-report_success.t
@@ -84,14 +84,14 @@ GET /t
 true
 true
 --- error_log
-healthy SUCCESS increment (1/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (2/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (3/3) for '(127.0.0.1:2116)'
-event: target status '(127.0.0.1:2116)' from 'false' to 'true'
-healthy SUCCESS increment (1/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (2/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (3/3) for '(127.0.0.1:2116)'
-event: target status '(127.0.0.1:2118)' from 'false' to 'true'
+healthy SUCCESS increment (1/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (2/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (3/3) for '127.0.0.1(127.0.0.1:2116)'
+event: target status '127.0.0.1(127.0.0.1:2116)' from 'false' to 'true'
+healthy SUCCESS increment (1/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (2/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (3/3) for '127.0.0.1(127.0.0.1:2116)'
+event: target status '127.0.0.1(127.0.0.1:2118)' from 'false' to 'true'
 
 
 === TEST 2: report_success() recovers TCP active = passive
@@ -159,14 +159,14 @@ GET /t
 true
 true
 --- error_log
-healthy SUCCESS increment (1/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (2/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (3/3) for '(127.0.0.1:2116)'
-event: target status '(127.0.0.1:2116)' from 'false' to 'true'
-healthy SUCCESS increment (1/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (2/3) for '(127.0.0.1:2116)'
-healthy SUCCESS increment (3/3) for '(127.0.0.1:2116)'
-event: target status '(127.0.0.1:2118)' from 'false' to 'true'
+healthy SUCCESS increment (1/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (2/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (3/3) for '127.0.0.1(127.0.0.1:2116)'
+event: target status '127.0.0.1(127.0.0.1:2116)' from 'false' to 'true'
+healthy SUCCESS increment (1/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (2/3) for '127.0.0.1(127.0.0.1:2116)'
+healthy SUCCESS increment (3/3) for '127.0.0.1(127.0.0.1:2116)'
+event: target status '127.0.0.1(127.0.0.1:2118)' from 'false' to 'true'
 
 === TEST 3: report_success() is a nop when active.healthy.sucesses == 0
 --- http_config eval
@@ -228,7 +228,7 @@ GET /t
 false
 --- no_error_log
 healthy SUCCESS increment
-event: target status '127.0.0.1 (127.0.0.1:2116)' from 'false' to 'true'
+event: target status '127.0.0.1(127.0.0.1:2116)' from 'false' to 'true'
 
 
 
@@ -292,4 +292,4 @@ GET /t
 false
 --- no_error_log
 healthy SUCCESS increment
-event: target status '(127.0.0.1:2118)' from 'false' to 'true'
+event: target status '127.0.0.1(127.0.0.1:2118)' from 'false' to 'true'

--- a/t/with_worker-events/05-report_failure.t
+++ b/t/with_worker-events/05-report_failure.t
@@ -84,14 +84,14 @@ GET /t
 false
 false
 --- error_log
-unhealthy HTTP increment (1/3) for '(127.0.0.1:2117)'
-unhealthy HTTP increment (2/3) for '(127.0.0.1:2117)'
-unhealthy HTTP increment (3/3) for '(127.0.0.1:2117)'
-event: target status '(127.0.0.1:2117)' from 'true' to 'false'
-unhealthy HTTP increment (1/3) for '(127.0.0.1:2113)'
-unhealthy HTTP increment (2/3) for '(127.0.0.1:2113)'
-unhealthy HTTP increment (3/3) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'true' to 'false'
+unhealthy HTTP increment (1/3) for '127.0.0.1(127.0.0.1:2117)'
+unhealthy HTTP increment (2/3) for '127.0.0.1(127.0.0.1:2117)'
+unhealthy HTTP increment (3/3) for '127.0.0.1(127.0.0.1:2117)'
+event: target status '127.0.0.1(127.0.0.1:2117)' from 'true' to 'false'
+unhealthy HTTP increment (1/3) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy HTTP increment (2/3) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy HTTP increment (3/3) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'true' to 'false'
 
 
 === TEST 2: report_failure() fails TCP active + passive
@@ -159,12 +159,12 @@ GET /t
 false
 false
 --- error_log
-unhealthy TCP increment (1/2) for '(127.0.0.1:2117)'
-unhealthy TCP increment (2/2) for '(127.0.0.1:2117)'
-event: target status '(127.0.0.1:2117)' from 'true' to 'false'
-unhealthy TCP increment (1/2) for '(127.0.0.1:2113)'
-unhealthy TCP increment (2/2) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'true' to 'false'
+unhealthy TCP increment (1/2) for '127.0.0.1(127.0.0.1:2117)'
+unhealthy TCP increment (2/2) for '127.0.0.1(127.0.0.1:2117)'
+event: target status '127.0.0.1(127.0.0.1:2117)' from 'true' to 'false'
+unhealthy TCP increment (1/2) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy TCP increment (2/2) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'true' to 'false'
 
 
 === TEST 3: report_failure() is a nop when failure counters == 0
@@ -232,9 +232,9 @@ GET /t
 true
 true
 --- no_error_log
-unhealthy TCP increment (1/2) for '(127.0.0.1:2117)'
-unhealthy TCP increment (2/2) for '(127.0.0.1:2117)'
-event: target status '(127.0.0.1:2117)' from 'true' to 'false'
-unhealthy TCP increment (1/2) for '(127.0.0.1:2113)'
-unhealthy TCP increment (2/2) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'true' to 'false'
+unhealthy TCP increment (1/2) for '127.0.0.1(127.0.0.1:2117)'
+unhealthy TCP increment (2/2) for '127.0.0.1(127.0.0.1:2117)'
+event: target status '127.0.0.1(127.0.0.1:2117)' from 'true' to 'false'
+unhealthy TCP increment (1/2) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy TCP increment (2/2) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'true' to 'false'

--- a/t/with_worker-events/06-report_http_status.t
+++ b/t/with_worker-events/06-report_http_status.t
@@ -84,14 +84,14 @@ GET /t
 false
 false
 --- error_log
-unhealthy HTTP increment (1/3) for '(127.0.0.1:2119)'
-unhealthy HTTP increment (2/3) for '(127.0.0.1:2119)'
-unhealthy HTTP increment (3/3) for '(127.0.0.1:2119)'
-event: target status '(127.0.0.1:2119)' from 'true' to 'false'
-unhealthy HTTP increment (1/3) for '(127.0.0.1:2113)'
-unhealthy HTTP increment (2/3) for '(127.0.0.1:2113)'
-unhealthy HTTP increment (3/3) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'true' to 'false'
+unhealthy HTTP increment (1/3) for '127.0.0.1(127.0.0.1:2119)'
+unhealthy HTTP increment (2/3) for '127.0.0.1(127.0.0.1:2119)'
+unhealthy HTTP increment (3/3) for '127.0.0.1(127.0.0.1:2119)'
+event: target status '127.0.0.1(127.0.0.1:2119)' from 'true' to 'false'
+unhealthy HTTP increment (1/3) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy HTTP increment (2/3) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy HTTP increment (3/3) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'true' to 'false'
 
 
 
@@ -162,16 +162,16 @@ GET /t
 true
 true
 --- error_log
-healthy SUCCESS increment (1/4) for '(127.0.0.1:2119)'
-healthy SUCCESS increment (2/4) for '(127.0.0.1:2119)'
-healthy SUCCESS increment (3/4) for '(127.0.0.1:2119)'
-healthy SUCCESS increment (4/4) for '(127.0.0.1:2119)'
-event: target status '(127.0.0.1:2119)' from 'false' to 'true'
-healthy SUCCESS increment (1/4) for '(127.0.0.1:2113)'
-healthy SUCCESS increment (2/4) for '(127.0.0.1:2113)'
-healthy SUCCESS increment (3/4) for '(127.0.0.1:2113)'
-healthy SUCCESS increment (4/4) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'false' to 'true'
+healthy SUCCESS increment (1/4) for '127.0.0.1(127.0.0.1:2119)'
+healthy SUCCESS increment (2/4) for '127.0.0.1(127.0.0.1:2119)'
+healthy SUCCESS increment (3/4) for '127.0.0.1(127.0.0.1:2119)'
+healthy SUCCESS increment (4/4) for '127.0.0.1(127.0.0.1:2119)'
+event: target status '127.0.0.1(127.0.0.1:2119)' from 'false' to 'true'
+healthy SUCCESS increment (1/4) for '127.0.0.1(127.0.0.1:2113)'
+healthy SUCCESS increment (2/4) for '127.0.0.1(127.0.0.1:2113)'
+healthy SUCCESS increment (3/4) for '127.0.0.1(127.0.0.1:2113)'
+healthy SUCCESS increment (4/4) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'false' to 'true'
 
 
 === TEST 3: report_http_status() with success is a nop when passive.healthy.successes == 0
@@ -235,7 +235,7 @@ GET /t
 false
 --- no_error_log
 healthy SUCCESS increment
-event: target status '127.0.0.1 (127.0.0.1:2119)' from 'false' to 'true'
+event: target status '127.0.0.1(127.0.0.1:2119)' from 'false' to 'true'
 
 
 === TEST 4: report_http_status() with success is a nop when active.healthy.successes == 0
@@ -299,7 +299,7 @@ GET /t
 false
 --- no_error_log
 healthy SUCCESS increment
-event: target status '127.0.0.1 (127.0.0.1:2119)' from 'false' to 'true'
+event: target status '127.0.0.1(127.0.0.1:2119)' from 'false' to 'true'
 
 
 === TEST 5: report_http_status() with failure is a nop when passive.unhealthy.http_failures == 0
@@ -363,7 +363,7 @@ GET /t
 true
 --- no_error_log
 unhealthy HTTP increment
-event: target status '127.0.0.1 (127.0.0.1:2119)' from 'true' to 'false'
+event: target status '127.0.0.1(127.0.0.1:2119)' from 'true' to 'false'
 
 
 === TEST 4: report_http_status() with success is a nop when active.unhealthy.http_failures == 0
@@ -427,7 +427,7 @@ GET /t
 true
 --- no_error_log
 unhealthy HTTP increment
-event: target status '(127.0.0.1:2119)' from 'true' to 'false'
+event: target status '127.0.0.1(127.0.0.1:2119)' from 'true' to 'false'
 
 
 === TEST 5: report_http_status() must work in log phase

--- a/t/with_worker-events/07-report_tcp_failure.t
+++ b/t/with_worker-events/07-report_tcp_failure.t
@@ -84,14 +84,14 @@ GET /t
 false
 false
 --- error_log
-unhealthy TCP increment (1/3) for '(127.0.0.1:2120)'
-unhealthy TCP increment (2/3) for '(127.0.0.1:2120)'
-unhealthy TCP increment (3/3) for '(127.0.0.1:2120)'
-event: target status '(127.0.0.1:2120)' from 'true' to 'false'
-unhealthy TCP increment (1/3) for '(127.0.0.1:2113)'
-unhealthy TCP increment (2/3) for '(127.0.0.1:2113)'
-unhealthy TCP increment (3/3) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'true' to 'false'
+unhealthy TCP increment (1/3) for '127.0.0.1(127.0.0.1:2120)'
+unhealthy TCP increment (2/3) for '127.0.0.1(127.0.0.1:2120)'
+unhealthy TCP increment (3/3) for '127.0.0.1(127.0.0.1:2120)'
+event: target status '127.0.0.1(127.0.0.1:2120)' from 'true' to 'false'
+unhealthy TCP increment (1/3) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy TCP increment (2/3) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy TCP increment (3/3) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'true' to 'false'
 
 
 === TEST 2: report_tcp_failure() for active is a nop when active.unhealthy.tcp_failures == 0
@@ -154,7 +154,7 @@ GET /t
 true
 --- no_error_log
 unhealthy TCP increment
-event: target status '(127.0.0.1:2120)' from 'true' to 'false'
+event: target status '127.0.0.1(127.0.0.1:2120)' from 'true' to 'false'
 
 
 
@@ -218,4 +218,4 @@ GET /t
 true
 --- no_error_log
 unhealthy TCP increment
-event: target status '(127.0.0.1:2120)' from 'true' to 'false'
+event: target status '127.0.0.1(127.0.0.1:2120)' from 'true' to 'false'

--- a/t/with_worker-events/08-report_timeout.t
+++ b/t/with_worker-events/08-report_timeout.t
@@ -84,12 +84,12 @@ GET /t
 false
 false
 --- error_log
-unhealthy TIMEOUT increment (1/2) for '(127.0.0.1:2122)'
-unhealthy TIMEOUT increment (2/2) for '(127.0.0.1:2122)'
-event: target status '(127.0.0.1:2122)' from 'true' to 'false'
-unhealthy TIMEOUT increment (1/2) for '(127.0.0.1:2113)'
-unhealthy TIMEOUT increment (2/2) for '(127.0.0.1:2113)'
-event: target status '(127.0.0.1:2113)' from 'true' to 'false'
+unhealthy TIMEOUT increment (1/2) for '127.0.0.1(127.0.0.1:2122)'
+unhealthy TIMEOUT increment (2/2) for '127.0.0.1(127.0.0.1:2122)'
+event: target status '127.0.0.1(127.0.0.1:2122)' from 'true' to 'false'
+unhealthy TIMEOUT increment (1/2) for '127.0.0.1(127.0.0.1:2113)'
+unhealthy TIMEOUT increment (2/2) for '127.0.0.1(127.0.0.1:2113)'
+event: target status '127.0.0.1(127.0.0.1:2113)' from 'true' to 'false'
 
 
 === TEST 2: report_timeout() for active is a nop when active.unhealthy.timeouts == 0
@@ -154,7 +154,7 @@ GET /t
 true
 --- no_error_log
 unhealthy TCP increment
-event: target status '(127.0.0.1:2122)' from 'true' to 'false'
+event: target status '127.0.0.1(127.0.0.1:2122)' from 'true' to 'false'
 
 
 
@@ -220,4 +220,4 @@ GET /t
 true
 --- no_error_log
 unhealthy TCP increment
-event: target status '(127.0.0.1:2122)' from 'true' to 'false'
+event: target status '127.0.0.1(127.0.0.1:2122)' from 'true' to 'false'

--- a/t/with_worker-events/11-clear.t
+++ b/t/with_worker-events/11-clear.t
@@ -167,7 +167,7 @@ true
 unhealthy HTTP increment (1/3) for '127.0.0.1(127.0.0.1:21120)'
 unhealthy HTTP increment (2/3) for '127.0.0.1(127.0.0.1:21120)'
 --- no_error_log
-unhealthy HTTP increment (3/3) for '(127.0.0.1:21120)'
+unhealthy HTTP increment (3/3) for '127.0.0.1(127.0.0.1:21120)'
 
 
 === TEST 4: delayed_clear() clears the list, after interval new checkers don't see it

--- a/t/with_worker-events/15-get_virtualhost_target_status.t
+++ b/t/with_worker-events/15-get_virtualhost_target_status.t
@@ -147,8 +147,8 @@ true
 true
 false
 --- error_log
-unhealthy HTTP increment (1/1) for '(127.0.0.1:2116)'
-event: target status '(127.0.0.1:2116)' from 'true' to 'false'
+unhealthy HTTP increment (1/1) for '127.0.0.1(127.0.0.1:2116)'
+event: target status '127.0.0.1(127.0.0.1:2116)' from 'true' to 'false'
 
 
 
@@ -293,7 +293,7 @@ false
 false
 false
 --- error_log
-unhealthy HTTP increment (1/1) for '(127.0.0.1:2118)'
-event: target status '(127.0.0.1:2118)' from 'true' to 'false'
+unhealthy HTTP increment (1/1) for '127.0.0.1(127.0.0.1:2118)'
+event: target status '127.0.0.1(127.0.0.1:2118)' from 'true' to 'false'
 unhealthy HTTP increment (1/1) for '127.0.0.1(127.0.0.1:2119)'
 event: target status '127.0.0.1(127.0.0.1:2119)' from 'true' to 'false'


### PR DESCRIPTION
Because when using `add_target` and `get_target`, if `hostname` is not specified, it will fallback to ip:
https://github.com/api7/lua-resty-healthcheck/blob/f1e644c9f23391f3f4d863076abd4a204d7af973/lib/resty/healthcheck.lua#L490-L493
https://github.com/api7/lua-resty-healthcheck/blob/f1e644c9f23391f3f4d863076abd4a204d7af973/lib/resty/healthcheck.lua#L473

However, the same logic is missing in the `incr_counter` function. This causes the hostname to be missing in the counter key in the shared memory when using the `report_http_status` function to report passive health check data, which further results in the `get_target_list` function being unable to correctly retrieve the counter data:

<img width="1710" height="173" alt="image" src="https://github.com/user-attachments/assets/81a25887-b778-4b7a-a9ed-2d77b60c5571" />
The screenshot above shows the data in the shared dict when using passive health. It can be seen that all entries in `target_list` contain `hostname`. However, because the `incr_counter` lacks fallback code for `hostname`, both the counter and state are recorded in the shared memory key that does not contain `hostname`.

https://github.com/api7/lua-resty-healthcheck/blob/f1e644c9f23391f3f4d863076abd4a204d7af973/lib/resty/healthcheck.lua#L1842-L1849

However, `get_target_list` needs to retrieve data from the shared dict through a key that includes `hostname`. Since the keys do not match, it cannot work.
