### PR TITLE
fix: release periodic lock when no active checkers exist

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1735,6 +1735,23 @@ function _M.new(opts)
       expire = function()
 
         if get_periodic_lock(shm, key) then
+          -- Check if there are any active checkers before renewing the lock.
+          -- When all checkers have been stopped (active=false), the lock holder
+          -- must release the lock so that other workers with active checkers
+          -- can acquire it.
+          local has_active_checker = false
+          for _, checker_obj in pairs(hcs) do
+            if checker_obj.checks.active.healthy.active or
+               checker_obj.checks.active.unhealthy.active then
+              has_active_checker = true
+              break
+            end
+          end
+          if not has_active_checker then
+            shm:delete(key)
+            active_check_timer.interval = CHECK_INTERVAL * 10
+            return
+          end
           active_check_timer.interval = CHECK_INTERVAL
           renew_periodic_lock(shm, key)
         else


### PR DESCRIPTION
## Problem

When all health checkers on a worker are stopped (`active=false`), the timer callback still acquires and renews the `PERIODIC_LOCK`, preventing other workers with active checkers from performing health checks.

This causes health checks to become permanently stuck after a disable → re-enable cycle:

1. Worker A holds the lock with active checkers — health check works ✓
2. Health check is disabled → `checker:stop()` sets `active=false`
3. Worker A's timer keeps running → acquires lock → renews it → but all checkers are inactive → does nothing
4. Health check is re-enabled → Worker B creates new active checker
5. Worker B's timer tries to acquire lock → **fails** (Worker A holds it) → backs off to `CHECK_INTERVAL * 10`
6. **Result**: Worker A holds lock but does no work; Worker B has active checker but can't get lock

### Root Cause

In the `expire` callback of `active_check_timer`:

```lua
if get_periodic_lock(shm, key) then
  active_check_timer.interval = CHECK_INTERVAL
  renew_periodic_lock(shm, key)   -- unconditionally renews!
else
  active_check_timer.interval = CHECK_INTERVAL * 10
  return
end
```

The lock is renewed **unconditionally** after acquisition, without checking whether the current worker has any active checkers. Meanwhile, `checker:stop()` only sets `active=false` but does not release the lock.

## Fix

After acquiring the periodic lock, check if there are any active checkers in the `hcs` table. If none exist, release the lock via `shm:delete(key)` and return, allowing other workers to acquire the lock.

```lua
if get_periodic_lock(shm, key) then
  local has_active_checker = false
  for _, checker_obj in pairs(hcs) do
    if checker_obj.checks.active.healthy.active or
       checker_obj.checks.active.unhealthy.active then
      has_active_checker = true
      break
    end
  end
  if not has_active_checker then
    shm:delete(key)
    active_check_timer.interval = CHECK_INTERVAL * 10
    return
  end
  active_check_timer.interval = CHECK_INTERVAL
  renew_periodic_lock(shm, key)
  ...
```

## Related

- https://github.com/apache/apisix/issues/13235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized periodic health check operations to skip unnecessary lock renewals when no active checks are enabled, reducing system resource consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->