### PR TITLE
feat: release v3.2.2

### DIFF
--- a/rockspecs/lua-resty-healthcheck-api7-3.2.2-0.rockspec
+++ b/rockspecs/lua-resty-healthcheck-api7-3.2.2-0.rockspec
@@ -1,0 +1,28 @@
+package = "lua-resty-healthcheck-api7"
+version = "3.2.2-0"
+source = {
+   url = "git://github.com/api7/lua-resty-healthcheck",
+   branch = "v3.2.2",
+}
+
+description = {
+   summary = "Healthchecks for OpenResty to check upstream service status",
+   detailed = [[
+      lua-resty-healthcheck is a module that can check upstream service
+      availability by sending requests and validating responses at timed
+      intervals.
+   ]],
+   homepage = "https://github.com/api7/lua-resty-healthcheck",
+   license = "Apache 2.0"
+}
+
+dependencies = {
+  "penlight >= 1.9.2",
+  "lua-resty-timer ~> 1",
+}
+build = {
+   type = "builtin",
+   modules = {
+      ["resty.healthcheck"] = "lib/resty/healthcheck.lua",
+   }
+}


### PR DESCRIPTION
## What

Release `v3.2.2` of `lua-resty-healthcheck-api7`. Adds the `3.2.2-0` rockspec (source `branch = "v3.2.2"`), following the convention of #52 (v3.2.1).

## Changes since v3.2.1

- #55 — fix: clean every checker each window and release periodic lock when idle.
  - **Cleanup**: stale-target cleanup is decoupled from active probing and the periodic lock, and a single worker per window is elected via an atomic `shm:add`, so purge-marked targets are removed across **all** health checkers — including passive-only deployments. Fixes the library-side root cause behind apache/apisix#13385 and apache/apisix#13141.
  - **Lock**: the periodic-lock holder releases the lock once it has no active checker left, so a worker that still owns active checkers can take over. Fixes apache/apisix#13235.

## After merge

Tag `v3.2.2` on the squash/merge commit (mirroring the `v3.2.1` tag on #52), then bump apisix's `lua-resty-healthcheck-api7` rockspec dependency to `3.2.2-0` so the cleanup/lock fixes reach apisix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added packaging metadata for `lua-resty-healthcheck-api7`, including versioning, repository details, and license information.
  * Declared runtime dependencies and module mapping to support installation and loading of the healthcheck library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->