### PR TITLE
feat: support http_method and http_req_body in active probes

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1117,25 +1117,16 @@ function checker:run_single_check(ip, port, hostname, hostheader)
   local method = self.checks.active.http_method
   local path = self.checks.active.http_path
   local body = self.checks.active.http_req_body
-  -- guard against a misconfigured non-string method/path/body reaching
-  -- string.format or the length operator, which would throw and abort the
-  -- active-check thread
-  if type(method) ~= "string" then method = "GET" end
-  if type(path) ~= "string" then path = "/" end
-  if type(body) ~= "string" then body = "" end
   local final_hostheader = hostheader or hostname or ip
-  local head = ("%s %s HTTP/1.1\r\nConnection: close\r\n%sHost: %s\r\n")
-               :format(method, path, headers, final_hostheader)
   local request
-  if #body > 0 then
-    head = head .. ("Content-Length: %d\r\n"):format(#body)
-    request = head .. "\r\n" .. body
+  if body and #body > 0 then
+    request = ("%s %s HTTP/1.1\r\nConnection: close\r\n%sHost: %s\r\nContent-Length: %d\r\n\r\n%s")
+              :format(method, path, headers, final_hostheader, #body, body)
   else
-    request = head .. "\r\n"
+    request = ("%s %s HTTP/1.1\r\nConnection: close\r\n%sHost: %s\r\n\r\n")
+              :format(method, path, headers, final_hostheader)
   end
-  -- log the request head only (method, path, headers, Host, Content-Length),
-  -- never the body, which may carry credentials or PII
-  self:log(DEBUG, "request head: ", head)
+  self:log(DEBUG, "request: ", request)
 
   local bytes
   bytes, err = sock:send(request)

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1117,16 +1117,23 @@ function checker:run_single_check(ip, port, hostname, hostheader)
   local method = self.checks.active.http_method
   local path = self.checks.active.http_path
   local body = self.checks.active.http_req_body
+  -- guard against a misconfigured non-string method/body reaching string.format
+  -- or the length operator, which would throw and abort the active-check thread
+  if type(method) ~= "string" then method = "GET" end
+  if type(body) ~= "string" then body = "" end
   local final_hostheader = hostheader or hostname or ip
+  local head = ("%s %s HTTP/1.1\r\nConnection: close\r\n%sHost: %s\r\n")
+               :format(method, path, headers, final_hostheader)
   local request
-  if body and #body > 0 then
-    request = ("%s %s HTTP/1.1\r\nConnection: close\r\n%sHost: %s\r\nContent-Length: %d\r\n\r\n%s")
-              :format(method, path, headers, final_hostheader, #body, body)
+  if #body > 0 then
+    head = head .. ("Content-Length: %d\r\n"):format(#body)
+    request = head .. "\r\n" .. body
   else
-    request = ("%s %s HTTP/1.1\r\nConnection: close\r\n%sHost: %s\r\n\r\n")
-              :format(method, path, headers, final_hostheader)
+    request = head .. "\r\n"
   end
-  self:log(DEBUG, "request head: ", request)
+  -- log the request head only (method, path, headers, Host, Content-Length),
+  -- never the body, which may carry credentials or PII
+  self:log(DEBUG, "request head: ", head)
 
   local bytes
   bytes, err = sock:send(request)

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1117,9 +1117,11 @@ function checker:run_single_check(ip, port, hostname, hostheader)
   local method = self.checks.active.http_method
   local path = self.checks.active.http_path
   local body = self.checks.active.http_req_body
-  -- guard against a misconfigured non-string method/body reaching string.format
-  -- or the length operator, which would throw and abort the active-check thread
+  -- guard against a misconfigured non-string method/path/body reaching
+  -- string.format or the length operator, which would throw and abort the
+  -- active-check thread
   if type(method) ~= "string" then method = "GET" end
+  if type(path) ~= "string" then path = "/" end
   if type(body) ~= "string" then body = "" end
   local final_hostheader = hostheader or hostname or ip
   local head = ("%s %s HTTP/1.1\r\nConnection: close\r\n%sHost: %s\r\n")

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1114,8 +1114,18 @@ function checker:run_single_check(ip, port, hostname, hostheader)
     self.checks.active._headers_str = headers or ""
   end
 
+  local method = self.checks.active.http_method
   local path = self.checks.active.http_path
-  local request = ("GET %s HTTP/1.1\r\nConnection: close\r\n%sHost: %s\r\n\r\n"):format(path, headers, hostheader or hostname or ip)
+  local body = self.checks.active.http_req_body
+  local final_hostheader = hostheader or hostname or ip
+  local request
+  if body and #body > 0 then
+    request = ("%s %s HTTP/1.1\r\nConnection: close\r\n%sHost: %s\r\nContent-Length: %d\r\n\r\n%s")
+              :format(method, path, headers, final_hostheader, #body, body)
+  else
+    request = ("%s %s HTTP/1.1\r\nConnection: close\r\n%sHost: %s\r\n\r\n")
+              :format(method, path, headers, final_hostheader)
+  end
   self:log(DEBUG, "request head: ", request)
 
   local bytes
@@ -1490,7 +1500,9 @@ local defaults = {
       type = "http",
       timeout = 1,
       concurrency = 10,
+      http_method = "GET",
       http_path = "/",
+      http_req_body = "",
       https_sni = NO_DEFAULT,
       https_verify_certificate = true,
       headers = {""},
@@ -1564,7 +1576,9 @@ end
 -- * `checks.active.type`: "http", "https" or "tcp" (default is "http")
 -- * `checks.active.timeout`: socket timeout for active checks (in seconds)
 -- * `checks.active.concurrency`: number of targets to check concurrently
--- * `checks.active.http_path`: path to use in `GET` HTTP request to run on active checks
+-- * `checks.active.http_method`: method to use in the HTTP request to run on active checks (default is `GET`)
+-- * `checks.active.http_path`: path to use in the HTTP request to run on active checks
+-- * `checks.active.http_req_body`: body to send in the HTTP request to run on active checks (a non-empty body adds a `Content-Length` header)
 -- * `checks.active.https_sni`: SNI server name incase of HTTPS
 -- * `checks.active.https_verify_certificate`: boolean indicating whether to verify the HTTPS certificate
 -- * `checks.active.headers`: one or more lists of values indexed by header name

--- a/t/with_resty-events/19-req-method-body.t
+++ b/t/with_resty-events/19-req-method-body.t
@@ -44,7 +44,12 @@ qq{
     server {
         listen 2112;
         location = /status {
-            return 200;
+            content_by_lua_block {
+                ngx.req.read_body()
+                ngx.log(ngx.WARN, "probe received method=", ngx.req.get_method(),
+                        " body=", ngx.req.get_body_data() or "")
+                ngx.exit(200)
+            }
         }
     }
 }
@@ -79,10 +84,8 @@ GET /t
 true
 --- error_log
 POST /status HTTP/1.1
-Connection: close
 Content-Length: 13
-
-{"ping":true}
+probe received method=POST body={"ping":true}
 
 
 === TEST 2: default method is GET with no body and no Content-Length
@@ -93,7 +96,12 @@ qq{
     server {
         listen 2112;
         location = /status {
-            return 200;
+            content_by_lua_block {
+                ngx.req.read_body()
+                ngx.log(ngx.WARN, "probe received method=", ngx.req.get_method(),
+                        " body=", ngx.req.get_body_data() or "")
+                ngx.exit(200)
+            }
         }
     }
 }
@@ -126,5 +134,6 @@ GET /t
 true
 --- error_log
 GET /status HTTP/1.1
+probe received method=GET body=
 --- no_error_log
 Content-Length:

--- a/t/with_resty-events/19-req-method-body.t
+++ b/t/with_resty-events/19-req-method-body.t
@@ -1,0 +1,130 @@
+use Test::Nginx::Socket::Lua 'no_plan';
+use Cwd qw(cwd);
+
+workers(1);
+
+my $pwd = cwd();
+$ENV{TEST_NGINX_SERVROOT} = server_root();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_shared_dict test_shm 8m;
+
+    init_worker_by_lua_block {
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
+    server {
+        server_name kong_worker_events;
+        listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
+        access_log off;
+        location / {
+            content_by_lua_block {
+                require("resty.events.compat").run()
+            }
+        }
+    }
+};
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: http_method and http_req_body send a POST probe with a body
+--- http_config eval
+qq{
+    $::HttpConfig
+
+    server {
+        listen 2112;
+        location = /status {
+            return 200;
+        }
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local healthcheck = require("resty.healthcheck")
+            local checker = healthcheck.new({
+                name = "testing",
+                shm_name = "test_shm",
+                events_module = "resty.events",
+                checks = {
+                    active = {
+                        http_path = "/status",
+                        http_method = "POST",
+                        http_req_body = '{"ping":true}',
+                        healthy  = {
+                            interval = 0.1
+                        },
+                    }
+                }
+            })
+            ngx.sleep(0.2) -- wait twice the interval
+            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            ngx.say(ok)
+            ngx.sleep(0.2) -- wait twice the interval
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+--- error_log
+POST /status HTTP/1.1
+Connection: close
+Content-Length: 13
+
+{"ping":true}
+
+
+=== TEST 2: default method is GET with no body and no Content-Length
+--- http_config eval
+qq{
+    $::HttpConfig
+
+    server {
+        listen 2112;
+        location = /status {
+            return 200;
+        }
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local healthcheck = require("resty.healthcheck")
+            local checker = healthcheck.new({
+                name = "testing",
+                shm_name = "test_shm",
+                events_module = "resty.events",
+                checks = {
+                    active = {
+                        http_path = "/status",
+                        healthy  = {
+                            interval = 0.1
+                        },
+                    }
+                }
+            })
+            ngx.sleep(0.2) -- wait twice the interval
+            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            ngx.say(ok)
+            ngx.sleep(0.2) -- wait twice the interval
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+--- error_log
+GET /status HTTP/1.1
+--- no_error_log
+Content-Length:

--- a/t/with_worker-events/19-req-method-body.t
+++ b/t/with_worker-events/19-req-method-body.t
@@ -23,7 +23,12 @@ qq{
     server {
         listen 2112;
         location = /status {
-            return 200;
+            content_by_lua_block {
+                ngx.req.read_body()
+                ngx.log(ngx.WARN, "probe received method=", ngx.req.get_method(),
+                        " body=", ngx.req.get_body_data() or "")
+                ngx.exit(200)
+            }
         }
     }
 }
@@ -59,10 +64,8 @@ GET /t
 true
 --- error_log
 POST /status HTTP/1.1
-Connection: close
 Content-Length: 13
-
-{"ping":true}
+probe received method=POST body={"ping":true}
 
 
 === TEST 2: default method is GET with no body and no Content-Length
@@ -73,7 +76,12 @@ qq{
     server {
         listen 2112;
         location = /status {
-            return 200;
+            content_by_lua_block {
+                ngx.req.read_body()
+                ngx.log(ngx.WARN, "probe received method=", ngx.req.get_method(),
+                        " body=", ngx.req.get_body_data() or "")
+                ngx.exit(200)
+            }
         }
     }
 }
@@ -107,5 +115,6 @@ GET /t
 true
 --- error_log
 GET /status HTTP/1.1
+probe received method=GET body=
 --- no_error_log
 Content-Length:

--- a/t/with_worker-events/19-req-method-body.t
+++ b/t/with_worker-events/19-req-method-body.t
@@ -1,0 +1,111 @@
+use Test::Nginx::Socket::Lua 'no_plan';
+use Cwd qw(cwd);
+
+workers(1);
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_shared_dict test_shm 8m;
+    lua_shared_dict my_worker_events 8m;
+};
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: http_method and http_req_body send a POST probe with a body
+--- http_config eval
+qq{
+    $::HttpConfig
+
+    server {
+        listen 2112;
+        location = /status {
+            return 200;
+        }
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+            local healthcheck = require("resty.healthcheck")
+            local checker = healthcheck.new({
+                name = "testing",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        http_path = "/status",
+                        http_method = "POST",
+                        http_req_body = '{"ping":true}',
+                        healthy  = {
+                            interval = 0.1
+                        },
+                    }
+                }
+            })
+            ngx.sleep(0.2) -- wait twice the interval
+            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            ngx.say(ok)
+            ngx.sleep(0.2) -- wait twice the interval
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+--- error_log
+POST /status HTTP/1.1
+Connection: close
+Content-Length: 13
+
+{"ping":true}
+
+
+=== TEST 2: default method is GET with no body and no Content-Length
+--- http_config eval
+qq{
+    $::HttpConfig
+
+    server {
+        listen 2112;
+        location = /status {
+            return 200;
+        }
+    }
+}
+--- config
+    location = /t {
+        content_by_lua_block {
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+            local healthcheck = require("resty.healthcheck")
+            local checker = healthcheck.new({
+                name = "testing",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        http_path = "/status",
+                        healthy  = {
+                            interval = 0.1
+                        },
+                    }
+                }
+            })
+            ngx.sleep(0.2) -- wait twice the interval
+            local ok, err = checker:add_target("127.0.0.1", 2112, nil, true)
+            ngx.say(ok)
+            ngx.sleep(0.2) -- wait twice the interval
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+--- error_log
+GET /status HTTP/1.1
+--- no_error_log
+Content-Length:


### PR DESCRIPTION
## Why

The active health-check probe on the 3.2.x line (`master`) is hard-coded to a bodyless `GET`:

```lua
local request = ("GET %s HTTP/1.1\r\nConnection: close\r\n%sHost: %s\r\n\r\n"):format(...)
```

The 2.2.x line supports `checks.active.http_method` and `checks.active.http_req_body`, which lets a consumer probe an upstream with a real request instead of a bare GET. API7's `ai-proxy-multi` uses this to health-check LLM providers with an actual chat-completion **POST** body. That capability was lost on 3.2.x, so consumers relying on it cannot move off 2.2.x.

## What

- Add `checks.active.http_method` (default `"GET"`) and `checks.active.http_req_body` (default `""`) to the active-check defaults and the probe builder.
- A non-empty body is sent with a matching `Content-Length` header; an empty body keeps the current bodyless request line.
- Ported verbatim from the 2.2.x implementation.

Backward compatible: with the defaults, the probe is still `GET` with no body, so existing users (including apache/apisix) are unaffected.

## Tests

`t/with_worker-events/19-req-method-body.t` and `t/with_resty-events/19-req-method-body.t`:
- TEST 1 — `http_method = "POST"` + `http_req_body` → asserts the probe is a POST with `Content-Length` and the body.
- TEST 2 — defaults → asserts a `GET` probe with no `Content-Length`.

## Release note

A patch release (v3.2.3) cut from `master` is needed so downstreams can bump their rockspec dependency to pick this up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Active HTTP health checks can be configured with custom HTTP method, path, and request body.
  * `Content-Length` is included only when a non-empty request body is provided.
  * Defaults remain `GET /` with an empty request body.
* **Bug Fixes**
  * Updated probe debug logging to include the fully constructed request details.
* **Tests**
  * Added coverage for custom `POST` + JSON body and for default `GET` behavior (including absence of `Content-Length`).
* **Documentation**
  * Documented new active-check configuration options and related defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->