### PR TITLE
feat: release v3.2.3

### DIFF
--- a/rockspecs/lua-resty-healthcheck-api7-3.2.3-0.rockspec
+++ b/rockspecs/lua-resty-healthcheck-api7-3.2.3-0.rockspec
@@ -1,0 +1,28 @@
+package = "lua-resty-healthcheck-api7"
+version = "3.2.3-0"
+source = {
+   url = "git://github.com/api7/lua-resty-healthcheck",
+   branch = "v3.2.3",
+}
+
+description = {
+   summary = "Healthchecks for OpenResty to check upstream service status",
+   detailed = [[
+      lua-resty-healthcheck is a module that can check upstream service
+      availability by sending requests and validating responses at timed
+      intervals.
+   ]],
+   homepage = "https://github.com/api7/lua-resty-healthcheck",
+   license = "Apache 2.0"
+}
+
+dependencies = {
+  "penlight >= 1.9.2",
+  "lua-resty-timer ~> 1",
+}
+build = {
+   type = "builtin",
+   modules = {
+      ["resty.healthcheck"] = "lib/resty/healthcheck.lua",
+   }
+}


### PR DESCRIPTION
Release v3.2.3.

Adds the `3.2.3-0` rockspec.

## Changes since v3.2.2

- feat: support `http_method` and `http_req_body` in active probes (#57) — the active-check probe can now be sent as any HTTP method with a request body (a non-empty body adds a `Content-Length` header). Defaults keep the previous `GET`-without-body behavior, so it is backward compatible.

## Post-merge

Tag `v3.2.3` and `luarocks upload rockspecs/lua-resty-healthcheck-api7-3.2.3-0.rockspec` so downstreams can depend on `3.2.3-0`.