### PR TITLE
fix: reconcile a worker's local target health from shm when a worker_events broadcast is missed

### DIFF
--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -142,6 +142,16 @@ local CHECK_JITTER = CHECK_INTERVAL * 0.1
 -- the check interval. If it does not update the shm during this period, we
 -- consider that it is not able to continue checking (the worker probably was killed)
 local LOCK_PERIOD = CHECK_INTERVAL * 15
+
+-- Only the periodic-lock holder ever runs active probes (see active_check_timer
+-- below), so every other worker's target.internal_health is updated *solely* by
+-- the worker_events broadcast raised in incr_counter. That broadcast has no
+-- delivery guarantee and, once a target is already at the reported health, is
+-- never raised again for the same state -- so a single missed event permanently
+-- strands a worker's local view (apache/apisix#13888). RECONCILE_INTERVAL bounds
+-- how long that divergence can last: every worker re-derives internal_health
+-- from the authoritative shm state on this cadence, independent of events.
+local RECONCILE_INTERVAL = 1
 -- interval between stale targets cleanup
 local CLEANUP_INTERVAL = CHECK_INTERVAL * 25
 
@@ -236,6 +246,10 @@ local hcs = setmetatable({}, {
 })
 
 local active_check_timer
+
+-- last time (ngx.now()) the shm-vs-local-cache reconciliation sweep ran; shared
+-- by all checkers on this worker since the sweep itself iterates `hcs`
+local last_reconcile_time = 0
 
 -- serialize a table to a string
 local serialize = codec.encode
@@ -1383,6 +1397,82 @@ function checker:event_handler(event_name, ip, port, hostname)
 end
 
 
+-- Re-derive a checker's local internal_health for every target the shm target
+-- list says exists, correcting any target whose cached value has drifted from
+-- a worker_events broadcast this worker never received (apache/apisix#13888),
+-- AND backfilling any target this worker's self.targets never even contains
+-- an entry for at all.
+--
+-- The second case is not hypothetical: add_target()'s "already exists in shm"
+-- branch (see its own comment) returns early without ever calling raise_event,
+-- so a worker whose *own* add_target call loses that race gets no event either
+-- -- and if this worker's initial checker.new() read of the target list also
+-- raced ahead of the writer (observed directly: "Got initial target list (0
+-- targets)" immediately followed by "adding an existing target ... (ignoring)"
+-- for every target), self.targets ends up with no entry for that target at
+-- all: not stale, structurally absent. Since checker_callback() only ever
+-- looks a target up via get_target(self, ...) against this same self.targets,
+-- such a target is permanently invisible to this worker's active-check cycle
+-- -- if this worker also holds the periodic probe lock (which never
+-- voluntarily rotates), NO worker ever probes that target again for the life
+-- of the process. Sourcing this sweep from fetch_target_list() (shm, the
+-- authoritative source used across the file, e.g. add_target/checker_callback
+-- itself) instead of iterating self.targets directly is what lets a missing
+-- entry be detected in the first place.
+local function reconcile_target_health(checker_obj)
+  local targets, err = fetch_target_list(checker_obj)
+  if not targets then
+    checker_obj:log(ERR, "reconcile: failed to fetch target list from shm: ", err)
+    return
+  end
+
+  for _, target in ipairs(targets) do
+    local state_key = key_for(checker_obj.TARGET_STATE, target.ip, target.port,
+                               target.hostname)
+    local raw_state = checker_obj.shm:get(state_key)
+    -- add_target() always writes TARGET_STATE before a target is considered
+    -- live (see its comment), so nil here means this read raced a concurrent
+    -- add/remove, not a genuine absence of state -- skip it for this sweep,
+    -- it will be consistent again on the next one.
+    if raw_state ~= nil then
+      local shm_health = INTERNAL_STATES[raw_state]
+      if shm_health then
+        local target_found = get_target(checker_obj, target.ip, target.port, target.hostname)
+        if not target_found then
+          -- lazily insert, mirroring event_handler's own "it is a new target,
+          -- must add it first" branch -- keeps both the ip/port/hostname
+          -- lookup table and the array part (used elsewhere, e.g. remove)
+          -- consistent with how every other insertion path populates them.
+          target_found = { ip = target.ip, port = target.port,
+                            hostname = target.hostname or target.ip }
+          checker_obj.targets[target_found.ip] = checker_obj.targets[target_found.ip] or {}
+          checker_obj.targets[target_found.ip][target_found.port] =
+            checker_obj.targets[target_found.ip][target_found.port] or {}
+          checker_obj.targets[target_found.ip][target_found.port][target_found.hostname] =
+            target_found
+          checker_obj.targets[#checker_obj.targets + 1] = target_found
+          checker_obj:log(WARN, "reconciled missing target from shm (never seen locally) '",
+                          target_found.hostname or "", "(", target_found.ip, ":",
+                          target_found.port, ")' as '", shm_health, "'")
+        elseif shm_health ~= target_found.internal_health then
+          local from = target_found.internal_health == "healthy" or
+                       target_found.internal_health == "mostly_healthy"
+          local to = shm_health == "healthy" or shm_health == "mostly_healthy"
+          if from ~= to then
+            checker_obj.status_ver = checker_obj.status_ver + 1
+          end
+          checker_obj:log(WARN, "reconciled target status from shm (missed event) '",
+                          target_found.hostname or "", "(", target_found.ip, ":",
+                          target_found.port, ")' from '", target_found.internal_health,
+                          "' to '", shm_health, "'")
+        end
+        target_found.internal_health = shm_health
+      end
+    end
+  end
+end
+
+
 ------------------------------------------------------------------------------
 -- Initializing.
 -- @section initializing
@@ -1749,6 +1839,19 @@ function _M.new(opts)
 
         local cur_time = ngx_now()
 
+        -- Self-heal from a missed worker_events broadcast (apache/apisix#13888).
+        -- Unlike the probing/cleanup elections below, this runs on EVERY worker
+        -- EVERY tick it's due, regardless of who owns the periodic/cleanup
+        -- locks -- a worker with no active checker of its own can still be
+        -- routing traffic off a stale cached status for a checker it merely
+        -- reads (get_target_status), so it must reconcile too.
+        if cur_time - last_reconcile_time >= RECONCILE_INTERVAL then
+          last_reconcile_time = cur_time
+          for _, checker_obj in pairs(hcs) do
+            reconcile_target_health(checker_obj)
+          end
+        end
+
         -- Stale-target cleanup is decoupled from active probing and the
         -- periodic lock. A passive-only deployment (checks.passive but no
         -- active interval) has no active checker on any worker, yet still marks
@@ -1932,6 +2035,14 @@ if TESTING then
   -- default CLEANUP_INTERVAL (CHECK_INTERVAL * 25).
   function _M._set_cleanup_interval(interval)
     CLEANUP_INTERVAL = interval
+  end
+
+  -- test-only hook: shorten the shm-vs-local-cache reconciliation cadence so
+  -- the self-heal path (apache/apisix#13888) can be exercised deterministically
+  -- without waiting for the default RECONCILE_INTERVAL.
+  function _M._set_reconcile_interval(interval)
+    RECONCILE_INTERVAL = interval
+    last_reconcile_time = 0
   end
 end
 

--- a/lib/resty/healthcheck.lua
+++ b/lib/resty/healthcheck.lua
@@ -1397,28 +1397,55 @@ function checker:event_handler(event_name, ip, port, hostname)
 end
 
 
+-- Remove a target from a checker's local cache only (self.targets), mirroring
+-- event_handler's own `events.remove` branch exactly (nested lookup table +
+-- array part), but without touching shm -- the shm side is already
+-- authoritative and, in the case this is called for, already has this target
+-- removed from it.
+local function remove_local_target(checker_obj, ip, port, hostname)
+  checker_obj.targets[ip][port][hostname] = nil
+  if not next(checker_obj.targets[ip][port]) then
+    checker_obj.targets[ip][port] = nil
+  end
+  if not next(checker_obj.targets[ip]) then
+    checker_obj.targets[ip] = nil
+  end
+  for i, t in ipairs(checker_obj.targets) do
+    if t.ip == ip and t.port == port and t.hostname == hostname then
+      table_remove(checker_obj.targets, i)
+      break
+    end
+  end
+end
+
+
 -- Re-derive a checker's local internal_health for every target the shm target
 -- list says exists, correcting any target whose cached value has drifted from
 -- a worker_events broadcast this worker never received (apache/apisix#13888),
--- AND backfilling any target this worker's self.targets never even contains
--- an entry for at all.
+-- backfilling any target this worker's self.targets never even contains an
+-- entry for at all, AND dropping any local target that shm no longer knows
+-- about (a missed `remove` broadcast is the same single-event, no-resend
+-- mechanism as a missed healthy/unhealthy one, and remove_target() mutates
+-- shm directly, exactly like incr_counter does for health state).
 --
--- The second case is not hypothetical: add_target()'s "already exists in shm"
--- branch (see its own comment) returns early without ever calling raise_event,
--- so a worker whose *own* add_target call loses that race gets no event either
--- -- and if this worker's initial checker.new() read of the target list also
--- raced ahead of the writer (observed directly: "Got initial target list (0
--- targets)" immediately followed by "adding an existing target ... (ignoring)"
--- for every target), self.targets ends up with no entry for that target at
--- all: not stale, structurally absent. Since checker_callback() only ever
--- looks a target up via get_target(self, ...) against this same self.targets,
--- such a target is permanently invisible to this worker's active-check cycle
--- -- if this worker also holds the periodic probe lock (which never
--- voluntarily rotates), NO worker ever probes that target again for the life
--- of the process. Sourcing this sweep from fetch_target_list() (shm, the
--- authoritative source used across the file, e.g. add_target/checker_callback
--- itself) instead of iterating self.targets directly is what lets a missing
--- entry be detected in the first place.
+-- The missing-target case is not hypothetical: add_target()'s "already exists
+-- in shm" branch (see its own comment) returns early without ever calling
+-- raise_event, so a worker whose *own* add_target call loses that race gets
+-- no event either -- and if this worker's initial checker.new() read of the
+-- target list also raced ahead of the writer (observed directly: "Got
+-- initial target list (0 targets)" immediately followed by "adding an
+-- existing target ... (ignoring)" for every target), self.targets ends up
+-- with no entry for that target at all: not stale, structurally absent.
+-- Since checker_callback() only ever looks a target up via get_target(self,
+-- ...) against this same self.targets, such a target is permanently
+-- invisible to this worker's active-check cycle -- if this worker also holds
+-- the periodic probe lock (which never voluntarily rotates), NO worker ever
+-- probes that target again for the life of the process. Sourcing this sweep
+-- from fetch_target_list() (shm, the authoritative source used across the
+-- file, e.g. add_target/checker_callback itself) instead of iterating
+-- self.targets directly is what lets a missing entry be detected in the
+-- first place, and is symmetrically what lets a stale local entry (removed
+-- from shm, never removed locally) be detected too.
 local function reconcile_target_health(checker_obj)
   local targets, err = fetch_target_list(checker_obj)
   if not targets then
@@ -1426,7 +1453,14 @@ local function reconcile_target_health(checker_obj)
     return
   end
 
+  -- authoritative set of target keys shm currently knows about, used below to
+  -- find local entries that shm no longer has (a missed `remove` broadcast)
+  local shm_keys = new_tab(0, #targets)
+
   for _, target in ipairs(targets) do
+    local hostname = target.hostname or target.ip
+    shm_keys[target.ip .. ":" .. target.port .. ":" .. hostname] = true
+
     local state_key = key_for(checker_obj.TARGET_STATE, target.ip, target.port,
                                target.hostname)
     local raw_state = checker_obj.shm:get(state_key)
@@ -1443,14 +1477,24 @@ local function reconcile_target_health(checker_obj)
           -- must add it first" branch -- keeps both the ip/port/hostname
           -- lookup table and the array part (used elsewhere, e.g. remove)
           -- consistent with how every other insertion path populates them.
-          target_found = { ip = target.ip, port = target.port,
-                            hostname = target.hostname or target.ip }
+          target_found = { ip = target.ip, port = target.port, hostname = hostname }
           checker_obj.targets[target_found.ip] = checker_obj.targets[target_found.ip] or {}
           checker_obj.targets[target_found.ip][target_found.port] =
             checker_obj.targets[target_found.ip][target_found.port] or {}
           checker_obj.targets[target_found.ip][target_found.port][target_found.hostname] =
             target_found
           checker_obj.targets[#checker_obj.targets + 1] = target_found
+
+          -- Mirror event_handler's boundary check: a target with no local
+          -- entry at all was not routable (get_target_status() returns
+          -- "target not found", never true), so backfilling it as healthy or
+          -- mostly_healthy is itself a not-routable -> routable transition a
+          -- consumer's cached routing view needs to know about.
+          local to = shm_health == "healthy" or shm_health == "mostly_healthy"
+          if to then
+            checker_obj.status_ver = checker_obj.status_ver + 1
+          end
+
           checker_obj:log(WARN, "reconciled missing target from shm (never seen locally) '",
                           target_found.hostname or "", "(", target_found.ip, ":",
                           target_found.port, ")' as '", shm_health, "'")
@@ -1469,6 +1513,37 @@ local function reconcile_target_health(checker_obj)
         target_found.internal_health = shm_health
       end
     end
+  end
+
+  -- Drop local targets shm no longer has at all -- a missed `remove` event is
+  -- the same single-shot, no-resend gap as a missed health-state event, and
+  -- get_target_status() returning stale "true" for a target already removed
+  -- from shm is a live routing bug, not just a cosmetic cache mismatch.
+  -- Iterate a snapshot of the array part since remove_local_target() mutates
+  -- it in place.
+  local stale = {}
+  for _, t in ipairs(checker_obj.targets) do
+    local hostname = t.hostname or t.ip
+    if not shm_keys[t.ip .. ":" .. t.port .. ":" .. hostname] then
+      stale[#stale + 1] = { ip = t.ip, port = t.port, hostname = hostname }
+    end
+  end
+  for _, t in ipairs(stale) do
+    -- a removal always moves a target off the routable side for whichever
+    -- boundary check consumers rely on (get_target_status returns
+    -- "target not found" afterwards, never true), so bump status_ver whenever
+    -- the target being dropped was still on the routable side locally.
+    local target_found = get_target(checker_obj, t.ip, t.port, t.hostname)
+    if target_found then
+      local from = target_found.internal_health == "healthy" or
+                   target_found.internal_health == "mostly_healthy"
+      if from then
+        checker_obj.status_ver = checker_obj.status_ver + 1
+      end
+    end
+    remove_local_target(checker_obj, t.ip, t.port, t.hostname)
+    checker_obj:log(WARN, "reconciled stale local target no longer in shm (missed remove event) '",
+                    t.hostname or "", "(", t.ip, ":", t.port, ")'")
   end
 end
 

--- a/t/with_resty-events/22-missed-event-reconcile.t
+++ b/t/with_resty-events/22-missed-event-reconcile.t
@@ -1,9 +1,7 @@
-use Test::Nginx::Socket::Lua;
+use Test::Nginx::Socket::Lua 'no_plan';
 use Cwd qw(cwd);
 
 workers(1);
-
-plan tests => repeat_each() * (blocks() * 3) - 2;
 
 my $pwd = cwd();
 $ENV{TEST_NGINX_SERVROOT} = server_root();

--- a/t/with_resty-events/22-missed-event-reconcile.t
+++ b/t/with_resty-events/22-missed-event-reconcile.t
@@ -1,0 +1,125 @@
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+workers(1);
+
+plan tests => repeat_each() * (blocks() * 3) - 2;
+
+my $pwd = cwd();
+$ENV{TEST_NGINX_SERVROOT} = server_root();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_shared_dict test_shm 8m;
+
+    init_worker_by_lua_block {
+        _G.__TESTING_HEALTHCHECKER = true
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
+    server {
+        server_name kong_worker_events;
+        listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
+        access_log off;
+        location / {
+            content_by_lua_block {
+                require("resty.events.compat").run()
+            }
+        }
+    }
+};
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: a target's local health cache self-heals from shm after a missed event
+# A worker's local self.targets cache is updated in two ways: (1) the
+# worker_events broadcast raised once per state transition by incr_counter,
+# or (2) nothing else -- get_target_status() only ever reads the local
+# cache, never shm. If a worker misses that one broadcast (a resty.events
+# delivery drop, or losing the add_target() "already exists in shm" race so
+# no event is raised for it in the first place), its view of that target's
+# health is permanently wrong: incr_counter never raises the same-state
+# transition again, so there is no second chance to receive it.
+#
+# This writes directly to the shared dict, bypassing incr_counter/raise_event
+# entirely, to simulate exactly that: shm updated, no event delivered. Before
+# the reconcile sweep runs, get_target_status() must still report the stale
+# ("healthy") value. After one sweep interval, it must have converged to the
+# shm value ("unhealthy") on its own, with no event ever posted for it.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local healthcheck = require("resty.healthcheck")
+            healthcheck._set_reconcile_interval(0.3)
+
+            local checker = healthcheck.new({
+                name = "test-missed-event-reconcile",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        healthy = { interval = 0 },
+                        unhealthy = { interval = 0 },
+                    },
+                },
+                events_module = "resty.events",
+            })
+            if not checker then
+                ngx.say("failed to create checker")
+                return
+            end
+
+            local ok, err = checker:add_target("127.0.0.1", 12345)
+            if not ok then
+                ngx.say("failed to add target: ", err)
+                return
+            end
+            ngx.sleep(0.2) -- let add_target's own event settle locally
+
+            local before = checker:get_target_status("127.0.0.1", 12345)
+            ngx.say("before shm write: ", tostring(before))
+
+            -- Simulate a dropped worker_events broadcast: mutate the
+            -- authoritative shm state directly, without incr_counter/raise_event.
+            local shm = ngx.shared["test_shm"]
+            local state_key = checker.TARGET_STATE .. ":127.0.0.1:12345:127.0.0.1"
+            local ok, err = shm:set(state_key, 2) -- INTERNAL_STATES[2] == "unhealthy"
+            if not ok then
+                ngx.say("failed to poke shm: ", err)
+                return
+            end
+
+            -- immediately after the shm write: the local cache has NOT been
+            -- told anything, so it must still read the pre-existing value
+            local immediately_after = checker:get_target_status("127.0.0.1", 12345)
+            ngx.say("immediately after shm write: ", tostring(immediately_after))
+
+            ngx.sleep(0.6) -- past the 0.3s test reconcile interval
+
+            local after_reconcile = checker:get_target_status("127.0.0.1", 12345)
+            ngx.say("after reconcile: ", tostring(after_reconcile))
+
+            checker:stop()
+        }
+    }
+--- request
+GET /t
+--- response_body
+before shm write: true
+immediately after shm write: true
+after reconcile: false
+--- grep_error_log eval
+qr/reconciled target status from shm/
+--- grep_error_log_out
+reconciled target status from shm
+--- no_error_log
+[error]
+--- timeout: 5

--- a/t/with_resty-events/23-missed-remove-event-reconcile.t
+++ b/t/with_resty-events/23-missed-remove-event-reconcile.t
@@ -1,0 +1,147 @@
+use Test::Nginx::Socket::Lua 'no_plan';
+use Cwd qw(cwd);
+
+workers(1);
+
+my $pwd = cwd();
+$ENV{TEST_NGINX_SERVROOT} = server_root();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_shared_dict test_shm 8m;
+
+    init_worker_by_lua_block {
+        _G.__TESTING_HEALTHCHECKER = true
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
+    server {
+        server_name kong_worker_events;
+        listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
+        access_log off;
+        location / {
+            content_by_lua_block {
+                require("resty.events.compat").run()
+            }
+        }
+    }
+};
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: a stale local target is dropped when shm no longer has it (missed remove event)
+# remove_target() mutates the TARGET_LIST (and TARGET_STATE) shm keys directly
+# and then raises a single `remove` broadcast -- the same single-shot,
+# no-resend mechanism incr_counter uses for health-state changes. A worker
+# that misses that one broadcast keeps a target in its local self.targets
+# cache that shm has already forgotten, so get_target_status() keeps
+# reporting the last-known (here: healthy) status for a target that no
+# longer exists at all, indefinitely.
+#
+# Simulate the drop by directly rewriting TARGET_LIST in shm to omit the
+# target, exactly what remove_target() itself does, without calling
+# remove_target() (so no `remove` event is ever posted). Before the reconcile
+# sweep, the local cache must still report the stale "true". After one sweep
+# interval, the target must be gone entirely (get_target_status errors with
+# "target not found", matching what a real removal looks like locally).
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local healthcheck = require("resty.healthcheck")
+            healthcheck._set_reconcile_interval(0.3)
+
+            local checker = healthcheck.new({
+                name = "test-missed-remove-reconcile",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        healthy = { interval = 0 },
+                        unhealthy = { interval = 0 },
+                    },
+                },
+                events_module = "resty.events",
+            })
+            if not checker then
+                ngx.say("failed to create checker")
+                return
+            end
+
+            -- keep a second, unrelated target so the sweep has to distinguish
+            -- "still present" from "gone" rather than just seeing an empty list
+            local ok, err = checker:add_target("127.0.0.1", 12347, nil, true)
+            if not ok then
+                ngx.say("failed to add target 12347: ", err)
+                return
+            end
+            local ok, err = checker:add_target("127.0.0.1", 12348, nil, true)
+            if not ok then
+                ngx.say("failed to add target 12348: ", err)
+                return
+            end
+            ngx.sleep(0.2) -- let both add_target events settle locally
+
+            local before = checker:get_target_status("127.0.0.1", 12347)
+            ngx.say("before shm removal: ", tostring(before))
+
+            -- Simulate a dropped `remove` broadcast: rewrite TARGET_LIST in
+            -- shm to omit the target, the same shm mutation remove_target()
+            -- itself performs, but skip its raise_event call entirely.
+            local ok, codec = pcall(require, "string.buffer")
+            if not ok then
+                codec = require("cjson.safe").new()
+            end
+            local shm = ngx.shared["test_shm"]
+            local raw = shm:get(checker.TARGET_LIST)
+            local target_list = codec.decode(raw)
+            local new_list = {}
+            for _, t in ipairs(target_list) do
+                if not (t.ip == "127.0.0.1" and t.port == 12347) then
+                    new_list[#new_list + 1] = t
+                end
+            end
+            local ok, err = shm:set(checker.TARGET_LIST, codec.encode(new_list))
+            if not ok then
+                ngx.say("failed to poke shm: ", err)
+                return
+            end
+
+            -- immediately after the shm write: the local cache has NOT been
+            -- told anything, so it must still report the pre-existing value
+            local immediately_after = checker:get_target_status("127.0.0.1", 12347)
+            ngx.say("immediately after shm removal: ", tostring(immediately_after))
+
+            ngx.sleep(0.6) -- past the 0.3s test reconcile interval
+
+            local after_reconcile, after_err = checker:get_target_status("127.0.0.1", 12347)
+            ngx.say("after reconcile: ", tostring(after_reconcile), " err: ", tostring(after_err))
+
+            -- the untouched target must still be there and unaffected
+            local other_status = checker:get_target_status("127.0.0.1", 12348)
+            ngx.say("untouched target still healthy: ", tostring(other_status))
+
+            checker:stop()
+        }
+    }
+--- request
+GET /t
+--- response_body
+before shm removal: true
+immediately after shm removal: true
+after reconcile: nil err: target not found
+untouched target still healthy: true
+--- grep_error_log eval
+qr/reconciled stale local target no longer in shm \(missed remove event\)/
+--- grep_error_log_out
+reconciled stale local target no longer in shm (missed remove event)
+--- no_error_log
+[error]
+--- timeout: 5

--- a/t/with_resty-events/24-reconcile-status-ver.t
+++ b/t/with_resty-events/24-reconcile-status-ver.t
@@ -1,0 +1,169 @@
+use Test::Nginx::Socket::Lua 'no_plan';
+use Cwd qw(cwd);
+
+workers(1);
+
+my $pwd = cwd();
+$ENV{TEST_NGINX_SERVROOT} = server_root();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_shared_dict test_shm 8m;
+
+    init_worker_by_lua_block {
+        _G.__TESTING_HEALTHCHECKER = true
+        local we = require "resty.events.compat"
+        assert(we.configure({
+            unique_timeout = 5,
+            broker_id = 0,
+            listening = "unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock"
+        }))
+        assert(we.configured())
+    }
+
+    server {
+        server_name kong_worker_events;
+        listen unix:$ENV{TEST_NGINX_SERVROOT}/worker_events.sock;
+        access_log off;
+        location / {
+            content_by_lua_block {
+                require("resty.events.compat").run()
+            }
+        }
+    }
+};
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: backfilling a never-seen-locally healthy target bumps status_ver
+# A target this worker's self.targets never held an entry for at all was not
+# routable (get_target_status returns "target not found", never true). Once
+# the reconcile sweep backfills it as healthy/mostly_healthy it becomes
+# routable, which is exactly the kind of transition status_ver exists to
+# signal to a consumer's routing cache -- so it must be bumped here the same
+# way event_handler bumps it for a normal add.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local healthcheck = require("resty.healthcheck")
+            healthcheck._set_reconcile_interval(0.3)
+
+            local checker = healthcheck.new({
+                name = "test-reconcile-status-ver-backfill",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        healthy = { interval = 0 },
+                        unhealthy = { interval = 0 },
+                    },
+                },
+                events_module = "resty.events",
+            })
+            if not checker then
+                ngx.say("failed to create checker")
+                return
+            end
+
+            -- Seed shm directly instead of add_target(): add_target() itself
+            -- raises an event that would backfill self.targets, defeating the
+            -- "never seen locally" scenario this test targets.
+            local shm = ngx.shared["test_shm"]
+            local ok, codec = pcall(require, "string.buffer")
+            if not ok then
+                codec = require("cjson.safe").new()
+            end
+            local target_list = { { ip = "127.0.0.1", port = 12349, hostname = "127.0.0.1" } }
+            assert(shm:set(checker.TARGET_LIST, codec.encode(target_list)))
+            assert(shm:set(checker.TARGET_STATE .. ":127.0.0.1:12349:127.0.0.1", 1)) -- "healthy"
+
+            local before_status, before_err = checker:get_target_status("127.0.0.1", 12349)
+            ngx.say("before reconcile: ", tostring(before_status), " err: ", tostring(before_err))
+            local before_ver = checker.status_ver
+
+            ngx.sleep(0.6) -- past the 0.3s test reconcile interval
+
+            local after_status = checker:get_target_status("127.0.0.1", 12349)
+            ngx.say("after reconcile: ", tostring(after_status))
+            ngx.say("status_ver bumped: ", tostring(checker.status_ver > before_ver))
+
+            checker:stop()
+        }
+    }
+--- request
+GET /t
+--- response_body
+before reconcile: nil err: target not found
+after reconcile: true
+status_ver bumped: true
+--- no_error_log
+[error]
+--- timeout: 5
+
+=== TEST 2: a stale local target removal bumps status_ver
+# A target dropped by the reconcile sweep (missed remove event) was routable
+# immediately beforehand (it was locally healthy); after the drop it is gone
+# entirely (not routable). That is a routable -> not-routable transition and
+# must bump status_ver the same way a genuine remove event does.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local healthcheck = require("resty.healthcheck")
+            healthcheck._set_reconcile_interval(0.3)
+
+            local checker = healthcheck.new({
+                name = "test-reconcile-status-ver-remove",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        healthy = { interval = 0 },
+                        unhealthy = { interval = 0 },
+                    },
+                },
+                events_module = "resty.events",
+            })
+            if not checker then
+                ngx.say("failed to create checker")
+                return
+            end
+
+            local ok, err = checker:add_target("127.0.0.1", 12350, nil, true)
+            if not ok then
+                ngx.say("failed to add target: ", err)
+                return
+            end
+            ngx.sleep(0.2) -- let add_target's own event settle locally
+
+            local before_ver = checker.status_ver
+
+            local ok, codec = pcall(require, "string.buffer")
+            if not ok then
+                codec = require("cjson.safe").new()
+            end
+            local shm = ngx.shared["test_shm"]
+            local ok2, err2 = shm:set(checker.TARGET_LIST, codec.encode({}))
+            if not ok2 then
+                ngx.say("failed to poke shm: ", err2)
+                return
+            end
+
+            ngx.sleep(0.6) -- past the 0.3s test reconcile interval
+
+            local after_status, after_err = checker:get_target_status("127.0.0.1", 12350)
+            ngx.say("after reconcile: ", tostring(after_status), " err: ", tostring(after_err))
+            ngx.say("status_ver bumped: ", tostring(checker.status_ver > before_ver))
+
+            checker:stop()
+        }
+    }
+--- request
+GET /t
+--- response_body
+after reconcile: nil err: target not found
+status_ver bumped: true
+--- no_error_log
+[error]
+--- timeout: 5

--- a/t/with_worker-events/22-missed-event-reconcile.t
+++ b/t/with_worker-events/22-missed-event-reconcile.t
@@ -1,0 +1,109 @@
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+workers(1);
+
+plan tests => repeat_each() * (blocks() * 3) - 2;
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_shared_dict test_shm 8m;
+    lua_shared_dict my_worker_events 8m;
+
+    init_worker_by_lua_block {
+        _G.__TESTING_HEALTHCHECKER = true
+    }
+};
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: a target's local health cache self-heals from shm after a missed event
+# A worker's local self.targets cache is updated in two ways: (1) the
+# worker_events broadcast raised once per state transition by incr_counter,
+# or (2) nothing else -- get_target_status() only ever reads the local
+# cache, never shm. If a worker misses that one broadcast (a worker_events
+# delivery drop, or losing the add_target() "already exists in shm" race so
+# no event is raised for it in the first place), its view of that target's
+# health is permanently wrong: incr_counter never raises the same-state
+# transition again, so there is no second chance to receive it.
+#
+# This writes directly to the shared dict, bypassing incr_counter/raise_event
+# entirely, to simulate exactly that: shm updated, no event delivered. Before
+# the reconcile sweep runs, get_target_status() must still report the stale
+# ("healthy") value. After one sweep interval, it must have converged to the
+# shm value ("unhealthy") on its own, with no event ever posted for it.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+
+            local healthcheck = require("resty.healthcheck")
+            healthcheck._set_reconcile_interval(0.3)
+
+            local checker = healthcheck.new({
+                name = "test-missed-event-reconcile",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        healthy = { interval = 0 },
+                        unhealthy = { interval = 0 },
+                    },
+                },
+            })
+            if not checker then
+                ngx.say("failed to create checker")
+                return
+            end
+
+            local ok, err = checker:add_target("127.0.0.1", 12345)
+            if not ok then
+                ngx.say("failed to add target: ", err)
+                return
+            end
+            ngx.sleep(0.2) -- let add_target's own event settle locally
+
+            local before = checker:get_target_status("127.0.0.1", 12345)
+            ngx.say("before shm write: ", tostring(before))
+
+            -- Simulate a dropped worker_events broadcast: mutate the
+            -- authoritative shm state directly, without incr_counter/raise_event.
+            local shm = ngx.shared["test_shm"]
+            local state_key = checker.TARGET_STATE .. ":127.0.0.1:12345:127.0.0.1"
+            local ok, err = shm:set(state_key, 2) -- INTERNAL_STATES[2] == "unhealthy"
+            if not ok then
+                ngx.say("failed to poke shm: ", err)
+                return
+            end
+
+            -- immediately after the shm write: the local cache has NOT been
+            -- told anything, so it must still read the pre-existing value
+            local immediately_after = checker:get_target_status("127.0.0.1", 12345)
+            ngx.say("immediately after shm write: ", tostring(immediately_after))
+
+            ngx.sleep(0.6) -- past the 0.3s test reconcile interval
+
+            local after_reconcile = checker:get_target_status("127.0.0.1", 12345)
+            ngx.say("after reconcile: ", tostring(after_reconcile))
+
+            checker:stop()
+        }
+    }
+--- request
+GET /t
+--- response_body
+before shm write: true
+immediately after shm write: true
+after reconcile: false
+--- grep_error_log eval
+qr/reconciled target status from shm/
+--- grep_error_log_out
+reconciled target status from shm
+--- no_error_log
+[error]
+--- timeout: 5

--- a/t/with_worker-events/22-missed-event-reconcile.t
+++ b/t/with_worker-events/22-missed-event-reconcile.t
@@ -1,9 +1,7 @@
-use Test::Nginx::Socket::Lua;
+use Test::Nginx::Socket::Lua 'no_plan';
 use Cwd qw(cwd);
 
 workers(1);
-
-plan tests => repeat_each() * (blocks() * 3) - 2;
 
 my $pwd = cwd();
 

--- a/t/with_worker-events/23-missed-remove-event-reconcile.t
+++ b/t/with_worker-events/23-missed-remove-event-reconcile.t
@@ -1,0 +1,131 @@
+use Test::Nginx::Socket::Lua 'no_plan';
+use Cwd qw(cwd);
+
+workers(1);
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_shared_dict test_shm 8m;
+    lua_shared_dict my_worker_events 8m;
+
+    init_worker_by_lua_block {
+        _G.__TESTING_HEALTHCHECKER = true
+    }
+};
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: a stale local target is dropped when shm no longer has it (missed remove event)
+# remove_target() mutates the TARGET_LIST (and TARGET_STATE) shm keys directly
+# and then raises a single `remove` broadcast -- the same single-shot,
+# no-resend mechanism incr_counter uses for health-state changes. A worker
+# that misses that one broadcast keeps a target in its local self.targets
+# cache that shm has already forgotten, so get_target_status() keeps
+# reporting the last-known (here: healthy) status for a target that no
+# longer exists at all, indefinitely.
+#
+# Simulate the drop by directly rewriting TARGET_LIST in shm to omit the
+# target, exactly what remove_target() itself does, without calling
+# remove_target() (so no `remove` event is ever posted). Before the reconcile
+# sweep, the local cache must still report the stale "true". After one sweep
+# interval, the target must be gone entirely (get_target_status errors with
+# "target not found", matching what a real removal looks like locally).
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+
+            local healthcheck = require("resty.healthcheck")
+            healthcheck._set_reconcile_interval(0.3)
+
+            local checker = healthcheck.new({
+                name = "test-missed-remove-reconcile",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        healthy = { interval = 0 },
+                        unhealthy = { interval = 0 },
+                    },
+                },
+            })
+            if not checker then
+                ngx.say("failed to create checker")
+                return
+            end
+
+            -- keep a second, unrelated target so the sweep has to distinguish
+            -- "still present" from "gone" rather than just seeing an empty list
+            local ok, err = checker:add_target("127.0.0.1", 12347, nil, true)
+            if not ok then
+                ngx.say("failed to add target 12347: ", err)
+                return
+            end
+            local ok, err = checker:add_target("127.0.0.1", 12348, nil, true)
+            if not ok then
+                ngx.say("failed to add target 12348: ", err)
+                return
+            end
+            ngx.sleep(0.2) -- let both add_target events settle locally
+
+            local before = checker:get_target_status("127.0.0.1", 12347)
+            ngx.say("before shm removal: ", tostring(before))
+
+            -- Simulate a dropped `remove` broadcast: rewrite TARGET_LIST in
+            -- shm to omit the target, the same shm mutation remove_target()
+            -- itself performs, but skip its raise_event call entirely.
+            local ok, codec = pcall(require, "string.buffer")
+            if not ok then
+                codec = require("cjson.safe").new()
+            end
+            local shm = ngx.shared["test_shm"]
+            local raw = shm:get(checker.TARGET_LIST)
+            local target_list = codec.decode(raw)
+            local new_list = {}
+            for _, t in ipairs(target_list) do
+                if not (t.ip == "127.0.0.1" and t.port == 12347) then
+                    new_list[#new_list + 1] = t
+                end
+            end
+            local ok, err = shm:set(checker.TARGET_LIST, codec.encode(new_list))
+            if not ok then
+                ngx.say("failed to poke shm: ", err)
+                return
+            end
+
+            -- immediately after the shm write: the local cache has NOT been
+            -- told anything, so it must still report the pre-existing value
+            local immediately_after = checker:get_target_status("127.0.0.1", 12347)
+            ngx.say("immediately after shm removal: ", tostring(immediately_after))
+
+            ngx.sleep(0.6) -- past the 0.3s test reconcile interval
+
+            local after_reconcile, after_err = checker:get_target_status("127.0.0.1", 12347)
+            ngx.say("after reconcile: ", tostring(after_reconcile), " err: ", tostring(after_err))
+
+            -- the untouched target must still be there and unaffected
+            local other_status = checker:get_target_status("127.0.0.1", 12348)
+            ngx.say("untouched target still healthy: ", tostring(other_status))
+
+            checker:stop()
+        }
+    }
+--- request
+GET /t
+--- response_body
+before shm removal: true
+immediately after shm removal: true
+after reconcile: nil err: target not found
+untouched target still healthy: true
+--- grep_error_log eval
+qr/reconciled stale local target no longer in shm \(missed remove event\)/
+--- grep_error_log_out
+reconciled stale local target no longer in shm (missed remove event)
+--- no_error_log
+[error]
+--- timeout: 5

--- a/t/with_worker-events/24-reconcile-status-ver.t
+++ b/t/with_worker-events/24-reconcile-status-ver.t
@@ -1,0 +1,155 @@
+use Test::Nginx::Socket::Lua 'no_plan';
+use Cwd qw(cwd);
+
+workers(1);
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_shared_dict test_shm 8m;
+    lua_shared_dict my_worker_events 8m;
+
+    init_worker_by_lua_block {
+        _G.__TESTING_HEALTHCHECKER = true
+    }
+};
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: backfilling a never-seen-locally healthy target bumps status_ver
+# A target this worker's self.targets never held an entry for at all was not
+# routable (get_target_status returns "target not found", never true). Once
+# the reconcile sweep backfills it as healthy/mostly_healthy it becomes
+# routable, which is exactly the kind of transition status_ver exists to
+# signal to a consumer's routing cache -- so it must be bumped here the same
+# way event_handler bumps it for a normal add.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+
+            local healthcheck = require("resty.healthcheck")
+            healthcheck._set_reconcile_interval(0.3)
+
+            local checker = healthcheck.new({
+                name = "test-reconcile-status-ver-backfill",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        healthy = { interval = 0 },
+                        unhealthy = { interval = 0 },
+                    },
+                },
+            })
+            if not checker then
+                ngx.say("failed to create checker")
+                return
+            end
+
+            -- Seed shm directly instead of add_target(): add_target() itself
+            -- raises an event that would backfill self.targets, defeating the
+            -- "never seen locally" scenario this test targets.
+            local shm = ngx.shared["test_shm"]
+            local ok, codec = pcall(require, "string.buffer")
+            if not ok then
+                codec = require("cjson.safe").new()
+            end
+            local target_list = { { ip = "127.0.0.1", port = 12349, hostname = "127.0.0.1" } }
+            assert(shm:set(checker.TARGET_LIST, codec.encode(target_list)))
+            assert(shm:set(checker.TARGET_STATE .. ":127.0.0.1:12349:127.0.0.1", 1)) -- "healthy"
+
+            local before_status, before_err = checker:get_target_status("127.0.0.1", 12349)
+            ngx.say("before reconcile: ", tostring(before_status), " err: ", tostring(before_err))
+            local before_ver = checker.status_ver
+
+            ngx.sleep(0.6) -- past the 0.3s test reconcile interval
+
+            local after_status = checker:get_target_status("127.0.0.1", 12349)
+            ngx.say("after reconcile: ", tostring(after_status))
+            ngx.say("status_ver bumped: ", tostring(checker.status_ver > before_ver))
+
+            checker:stop()
+        }
+    }
+--- request
+GET /t
+--- response_body
+before reconcile: nil err: target not found
+after reconcile: true
+status_ver bumped: true
+--- no_error_log
+[error]
+--- timeout: 5
+
+=== TEST 2: a stale local target removal bumps status_ver
+# A target dropped by the reconcile sweep (missed remove event) was routable
+# immediately beforehand (it was locally healthy); after the drop it is gone
+# entirely (not routable). That is a routable -> not-routable transition and
+# must bump status_ver the same way a genuine remove event does.
+--- http_config eval: $::HttpConfig
+--- config
+    location /t {
+        content_by_lua_block {
+            local we = require "resty.worker.events"
+            assert(we.configure{ shm = "my_worker_events", interval = 0.1 })
+
+            local healthcheck = require("resty.healthcheck")
+            healthcheck._set_reconcile_interval(0.3)
+
+            local checker = healthcheck.new({
+                name = "test-reconcile-status-ver-remove",
+                shm_name = "test_shm",
+                checks = {
+                    active = {
+                        healthy = { interval = 0 },
+                        unhealthy = { interval = 0 },
+                    },
+                },
+            })
+            if not checker then
+                ngx.say("failed to create checker")
+                return
+            end
+
+            local ok, err = checker:add_target("127.0.0.1", 12350, nil, true)
+            if not ok then
+                ngx.say("failed to add target: ", err)
+                return
+            end
+            ngx.sleep(0.2) -- let add_target's own event settle locally
+
+            local before_ver = checker.status_ver
+
+            local ok, codec = pcall(require, "string.buffer")
+            if not ok then
+                codec = require("cjson.safe").new()
+            end
+            local shm = ngx.shared["test_shm"]
+            local ok2, err2 = shm:set(checker.TARGET_LIST, codec.encode({}))
+            if not ok2 then
+                ngx.say("failed to poke shm: ", err2)
+                return
+            end
+
+            ngx.sleep(0.6) -- past the 0.3s test reconcile interval
+
+            local after_status, after_err = checker:get_target_status("127.0.0.1", 12350)
+            ngx.say("after reconcile: ", tostring(after_status), " err: ", tostring(after_err))
+            ngx.say("status_ver bumped: ", tostring(checker.status_ver > before_ver))
+
+            checker:stop()
+        }
+    }
+--- request
+GET /t
+--- response_body
+after reconcile: nil err: target not found
+status_ver bumped: true
+--- no_error_log
+[error]
+--- timeout: 5


### PR DESCRIPTION
## Problem

`incr_counter()` raises a `worker_events` broadcast only once, at the exact moment a target's health state transitions. `get_target_status()` reads only a worker's own local `self.targets` cache, never shm. If a worker misses that single broadcast, it never gets another chance to learn the target's real health: the same-state transition is never re-broadcast, so the worker's local view of that target is now permanently wrong (until some _other_ transition happens to fire another event).

This is not just a theoretical race. Two concrete ways to hit it:

1. A `resty.events`/`worker.events` delivery drop for that one broadcast.
2. `add_target()`'s "already exists in shm" early-return path (see its own comment) returns without ever calling `raise_event`, so a worker whose own `add_target` call loses that startup race against another worker gets no event either. If that worker's initial `checker.new()` read of the target list also raced ahead of the writer, `self.targets` ends up with **no entry at all** for that target: not stale, structurally absent. Since `checker_callback()` only ever looks a target up via `get_target(self, ...)` against that same `self.targets`, such a target becomes permanently invisible to that worker's active-check cycle, and if that worker also holds the periodic probe lock (which never voluntarily rotates), no worker ever probes it again for the life of the process.

In a multi-worker deployment, this means a worker can keep routing traffic to a target that every other worker (and shm) already knows is unhealthy, a missed housekeeping broadcast becomes a real, silent, indefinite routing bug.

## Fix

Add a periodic reconciliation sweep (`RECONCILE_INTERVAL`, default 1s) that runs on **every** worker, regardless of which one holds the periodic-probe or cleanup locks, and re-derives each target's `internal_health` directly from the authoritative shm state via the existing `fetch_target_list()`. This also backfills any target a worker's `self.targets` never held an entry for at all (case 2 above), by sourcing the sweep from shm instead of iterating `self.targets` directly.

The sweep only bumps `status_ver` when a correction actually crosses the healthy/unhealthy boundary (i.e. changes what `get_target_status()` would return), to avoid unnecessary balancer cache invalidation for purely cosmetic sub-state changes (e.g. `mostly_healthy` to `healthy`).

## Validation

- **Deterministic unit tests** (new, both event backends): directly poke shm to simulate a dropped broadcast (bypassing `incr_counter`/`raise_event` entirely) and assert `get_target_status()` is still stale immediately after, then self-heals to the shm value after one `RECONCILE_INTERVAL`, with no event ever posted for it.
- **Live reproduction**: reproduced this independently in a real multi-worker Kubernetes deployment under genuine concurrent traffic (an active-vs-passive check disagreement was used to force live health-state churn on an already-running process). Caught multiple real worker/shm divergences, including one where a worker's local cache stayed at `mostly_healthy` (routable, per `get_target_status()`) for a period after shm had already recorded `unhealthy`, i.e. the worker was actively routing traffic to a target it should have excluded, and watched this patch catch and correct it within one `RECONCILE_INTERVAL`.
- **Stock-vs-patched comparison**: built a variant that performs the same divergence _detection_ as this patch but deliberately skips the correction, to make the (otherwise completely silent) stock behavior observable side by side. Under identical live traffic, the unpatched- equivalent build hit the same divergence condition repeatedly and would have left every occurrence uncorrected, confirming this is a real, live-reproducible gap in current behavior, not just a theoretical race.

## Notes

- This is a local/vendored patch validated against `v3.2.3`; happy to rebase against `master`/`devel` or adjust naming/interval conventions to match whatever this repo prefers.
- `RECONCILE_INTERVAL` is currently a fixed local, not exposed as a `checks`/`new()` option. Open to making it configurable if that's preferred, though I'd lean toward keeping it fixed and small (this is a correctness backstop, not a tuning knob) unless there's a reason a consumer would want a longer interval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved health-status consistency across workers by automatically reconciling local target data with authoritative shared state.
  - Added recovery for missed health-update events, including discovery of missing targets and correction of stale healthy/unhealthy statuses.
  - Health status now converges automatically at a configurable interval, independent of probing and cleanup activity.

- **Tests**
  - Added coverage for missed-event recovery and verification of reconciliation logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
